### PR TITLE
bw_io_error_writer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@ mod live_events;
 pub mod options;
 mod parse_scalars;
 mod ser;
+
+pub mod ser_error;
+
 mod serializer_options;
 mod tags;
 
@@ -178,7 +181,10 @@ pub fn to_io_writer_with_options<W: std::io::Write, T: serde::Serialize>(
             self.write_str(s)
         }
     }
-    let mut adapter = Adapter { output: output, last_err: None };
+    let mut adapter = Adapter {
+        output: output,
+        last_err: None,
+    };
     let mut ser = crate::ser::YamlSer::with_options(&mut adapter, &mut options);
     match value.serialize(&mut ser) {
         Ok(()) => Ok(()),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -63,6 +63,11 @@ impl From<fmt::Error> for Error {
         Error(e.to_string())
     }
 }
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error(e.to_string())
+    }
+}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { f.write_str(&self.0) }
 }

--- a/src/ser_error.rs
+++ b/src/ser_error.rs
@@ -1,0 +1,107 @@
+use std::{fmt, io};
+
+/// Error type used by the YAML serializer.
+///
+/// This type is re-exported as `serde_saphyr::ser::Error` and is returned by
+/// the public serialization APIs (for example `serde_saphyr::to_string`).
+///
+/// It implements `serde::ser::Error`, which allows user `Serialize` impls and
+/// Serde derives to report failures via `S::Error::custom(...)`. Such
+/// free‑form messages are stored in the `Message` variant.
+///
+/// Other variants wrap concrete underlying failures that can occur while
+/// serializing:
+/// - `Format` wraps a `core::fmt::Error` produced when writing to a
+///   `fmt::Write` target.
+/// - `IO` wraps a `std::io::Error` produced when writing to an `io::Write`
+///   target.
+/// - `Unexpected` is used internally for invariant violations (e.g. around
+///   anchors). It should not normally surface; if it does, please file a bug.
+#[derive(Debug)]
+pub enum Error {
+    /// Free-form error.
+    Message { msg: String },
+    /// Wrapper for formatting errors.
+    Format { error: fmt::Error },
+    /// Wrapper for I/O errors.
+    IO { error: io::Error },
+    /// This is used with anchors and should normally not surface, please report bug if it does.
+    Unexpected { msg: String }
+}
+
+impl serde::ser::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Error::Message {
+            msg: msg.to_string(),
+        }
+    }
+}
+
+impl From<fmt::Error> for Error {
+    fn from(error: fmt::Error) -> Self {
+        Error::Format { error }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Error::IO { error }
+    }
+}
+
+impl From<String> for Error
+{
+    fn from(message: String) -> Self {
+        Error::Message {
+            msg: message,
+        }
+    }
+}
+
+impl From<&String> for Error
+{
+    fn from(message: &String) -> Self {
+        Error::Message {
+            msg: message.clone(),
+        }
+    }
+}
+
+impl From<&str> for Error
+{
+    fn from(message: &str) -> Self {
+        Error::Message {
+            msg: message.to_string(),
+        }
+    }
+}
+
+impl Error {
+    pub(crate) fn unexpected(message: &str) -> Self {
+        Error::Unexpected {
+            msg: message.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Message { msg } => f.write_str(msg),
+            Error::Format { error } => write!(f, "formatting error: {error}"),
+            Error::IO { error } => write!(f, "I/O error: {error}"),
+            Error::Unexpected { msg } => write!(f, "unexpected internal error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Message { .. } => None,
+            Error::Unexpected { .. } => None,
+            Error::Format { error } => Some(error),
+            Error::IO { error } => Some(error),
+        }
+    }
+}

--- a/tests/serialize_basic.rs
+++ b/tests/serialize_basic.rs
@@ -97,11 +97,11 @@ fn serialize_nested_variant_enums() {
     // Also exercise to_writer and to_writer_with_indent
     let v = Outer::Beta { inner: Inner::Unit, note: "ok".into() };
     let mut buf = String::new();
-    serde_saphyr::to_writer(&mut buf, &v).expect("to_writer works");
+    serde_saphyr::to_fmt_writer(&mut buf, &v).expect("to_writer works");
     assert!(!buf.is_empty());
     let mut buf2 = String::new();
     let opts = serde_saphyr::SerializerOptions { indent_step: 4, anchor_generator: None };
-    serde_saphyr::to_writer_with_options(&mut buf2, &v, opts).expect("to_writer_with_options works");
+    serde_saphyr::to_fmt_writer_with_options(&mut buf2, &v, opts).expect("to_writer_with_options works");
     assert!(!buf2.is_empty());
 }
 
@@ -116,7 +116,19 @@ fn serialize_array_of_empty_maps() {
         vec: vec![Default::default(), Default::default(), Default::default()],
     };
     let mut buf = String::new();
-    serde_saphyr::to_writer(&mut buf, &v).expect("to_writer works");
+    serde_saphyr::to_fmt_writer(&mut buf, &v).expect("to_writer works");
     let v2: VecOfMaps = serde_saphyr::from_str(&buf).expect("deserialize just serialized data");
+    assert_eq!(v, v2);
+}
+
+#[test]
+fn serialize_array_of_empty_maps_to_io() {
+    let v = VecOfMaps {
+        vec: vec![Default::default(), Default::default(), Default::default()],
+    };
+    let mut buf: Vec<u8> = Vec::new();
+    serde_saphyr::to_io_writer(&mut buf, &v).expect("to_writer works");
+    let s = String::from_utf8(buf).expect("valid utf-8");
+    let v2: VecOfMaps = serde_saphyr::from_str(&s).expect("deserialize just serialized data");
     assert_eq!(v, v2);
 }


### PR DESCRIPTION
The error is not enum, allowing to inspect the internals, including the wrapped io::Error that is likely the most of the interest.