### PR TITLE
bw_expose_serializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,10 +656,20 @@ dependencies = [
  "ryu",
  "saphyr-parser",
  "serde",
+ "serde-transcode",
  "serde_bytes",
  "serde_json",
  "serde_repr",
  "smallvec 2.0.0-alpha.12",
+]
+
+[[package]]
+name = "serde-transcode"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "ahash",
  "annotate-snippets",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,9 @@ dependencies = [
  "serde",
  "serde-transcode",
  "serde_bytes",
+ "serde_ignored",
  "serde_json",
+ "serde_path_to_error",
  "serde_repr",
  "smallvec 2.0.0-alpha.12",
 ]
@@ -703,6 +705,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +724,17 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
  "serde",
  "serde_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ chrono = "0.4"
 regex = "1.12"
 nalgebra = { version = "0.34", features = ["serde-serialize"] }
 serde-transcode = "1.1.1" # we only use in tests
+serde_ignored = "0.1"
+serde_path_to_error = "0.1"
 
 [package.metadata]
 status = "actively developed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ robotics = []
 indoc = { version = ">= 2.0.6, < 2.1"}
 serde_bytes = "0.11"
 serde = { version = "1.0", features = ["derive", "rc"] }
-serde-transcode = "1.1.1"
 serde_repr = "0.1.20"
 anyhow = "1.0"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ encoding_rs_io = "0.1.7"
 ahash = "0.8.12"
 annotate-snippets = "0.12"
 garde = { version = ">= 0.19.0, < 0.23", optional = true, features = ["derive"] }
-serde-transcode = "1.1.1"
 
 [features]
 default = []
@@ -46,6 +45,7 @@ anyhow = "1.0"
 chrono = "0.4"
 regex = "1.12"
 nalgebra = { version = "0.34", features = ["serde-serialize"] }
+serde-transcode = "1.1.1" # we only use in tests
 
 [package.metadata]
 status = "actively developed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ robotics = []
 indoc = { version = ">= 2.0.6, < 2.1"}
 serde_bytes = "0.11"
 serde = { version = "1.0", features = ["derive", "rc"] }
+serde-transcode = "1.1.1"
 serde_repr = "0.1.20"
 anyhow = "1.0"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-saphyr"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 license = "MIT"
 description = "YAML (de)serializer for Serde, built on top of Saphyr, emphasizing panic-free parsing."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ encoding_rs_io = "0.1.7"
 ahash = "0.8.12"
 annotate-snippets = "0.12"
 garde = { version = ">= 0.19.0, < 0.23", optional = true, features = ["derive"] }
+serde-transcode = "1.1.1"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The test suite currently includes 783 passing tests, most of them originating fr
 - **First class [`garde`](https://crates.io/crates/garde) integration:** Declarative validation of parsed YAML documents, reporting location with snippet directly from YAML document.
 - **serde_json::Value** is supported when parsing without target structure defined.
 - **robotic extensions** to support YAML dialect common in robotics (see below).
-- **[Serializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Serializer.html) and [Deserializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Deserializer.html) are now public (due how its implemented, Deserializer is available in the closure only.
+- **[Serializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Serializer.html)** and **[Deserializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Deserializer.html)** are now public (due how its implemented, Deserializer is available in the closure only.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The test suite currently includes 783 passing tests, most of them originating fr
 - **First class [`garde`](https://crates.io/crates/garde) integration:** Declarative validation of parsed YAML documents, reporting location with snippet directly from YAML document.
 - **serde_json::Value** is supported when parsing without target structure defined.
 - **robotic extensions** to support YAML dialect common in robotics (see below).
-- **[Serializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Serializer.html) and [Deserializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Deserializer.html) are now public (due how its implemented, Deserializer is available in the closure onl.
+- **[Serializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Serializer.html) and [Deserializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Deserializer.html) are now public (due how its implemented, Deserializer is available in the closure only.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The test suite currently includes 783 passing tests, most of them originating fr
 - **First class [`garde`](https://crates.io/crates/garde) integration:** Declarative validation of parsed YAML documents, reporting location with snippet directly from YAML document.
 - **serde_json::Value** is supported when parsing without target structure defined.
 - **robotic extensions** to support YAML dialect common in robotics (see below).
+- **[Serializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Serializer.html) and [Deserializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Deserializer.html) are now public (due how its implemented, Deserializer is available in the closure onl.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The test suite currently includes 783 passing tests, most of them originating fr
 - **First class [`garde`](https://crates.io/crates/garde) integration:** Declarative validation of parsed YAML documents, reporting location with snippet directly from YAML document.
 - **serde_json::Value** is supported when parsing without target structure defined.
 - **robotic extensions** to support YAML dialect common in robotics (see below).
-- **[Serializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Serializer.html)** and **[Deserializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Deserializer.html)** are now public (due how its implemented, Deserializer is available in the closure only.
+- **[Serializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Serializer.html)** and **[Deserializer](https://docs.rs/serde-saphyr/latest/serde_saphyr/struct.Deserializer.html)** are now public (due how its implemented, Deserializer is available in the closure only).
 
 ## Usage
 

--- a/examples/serde_ignored.rs
+++ b/examples/serde_ignored.rs
@@ -1,0 +1,97 @@
+/*
+  examples/serde_ignored.rs
+
+  Goal
+  ----
+  Show how to report *unknown / ignored* fields while deserializing YAML.
+
+  Why would you want this?
+  ------------------------
+  When you deserialize into a Rust struct, Serde normally ignores fields that
+  are present in the input but not present in your struct (unless you opt into
+  `#[serde(deny_unknown_fields)]`, which turns unknown fields into a hard error).
+
+  In configuration files, a *warning* is often the best behavior:
+    - It helps users spot typos ("enabeld" instead of "enabled").
+    - It helps detect stale config knobs after upgrades.
+    - It keeps backwards/forwards compatibility (unknown fields don't fail the load).
+
+  The `serde_ignored` crate provides this warning behavior by wrapping a Serde
+  deserializer and calling you back for every ignored path.
+
+  This example uses:
+    - `serde_saphyr::with_deserializer_from_str` to obtain a streaming YAML deserializer
+      (you cannot return the deserializer directly because it borrows parsing state).
+    - `serde_ignored::deserialize` to collect the ignored fields.
+
+  Running
+  -------
+  cargo run --example serde_ignored
+*/
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Config {
+    enabled: bool,
+    retries: i32,
+    server: Server,
+}
+
+#[derive(Debug, Deserialize)]
+struct Server {
+    host: String,
+    port: u16,
+}
+
+fn main() {
+    // Input YAML deliberately contains a few unknown fields.
+    //
+    // Notes:
+    // - `enabeld` is a typo and will be ignored (because the struct expects `enabled`).
+    // - `server.timeoutMs` does not exist in `Server` and will be ignored.
+    // - `topLevelExtra` is not in `Config` and will be ignored.
+    let yaml = r#"
+        enabled: true
+        retries: 5
+
+        # typo: should be `enabled`
+        enabeld: false
+
+        server:
+          host: localhost
+          port: 8080
+          timeoutMs: 250
+
+        topLevelExtra: "surprise"
+    "#;
+
+    // Collect ignored paths as strings so we can print them later.
+    //
+    // `serde_ignored` reports paths in a structured form; converting to string
+    // is convenient for human-facing diagnostics.
+    let mut ignored = Vec::<String>::new();
+
+    let cfg: Config = serde_saphyr::with_deserializer_from_str(yaml, |de| {
+        // `serde_ignored::deserialize` behaves like `T::deserialize(de)`, but it
+        // also calls our callback for every ignored path.
+        serde_ignored::deserialize(de, |path| ignored.push(path.to_string()))
+    })
+    .expect("YAML input must deserialize into Config");
+
+    // Your app can now decide how to surface ignored fields.
+    //
+    // Typical policies are:
+    // - print warnings (most common)
+    // - log warnings with file/line context
+    // - treat some prefixes as errors
+    if !ignored.is_empty() {
+        eprintln!("Ignored (unknown) fields:");
+        for p in &ignored {
+            eprintln!("  - {p}");
+        }
+    }
+
+    println!("Parsed config: {cfg:?}");
+}

--- a/examples/serde_ignored.rs
+++ b/examples/serde_ignored.rs
@@ -33,6 +33,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 struct Config {
     enabled: bool,
     retries: i32,
@@ -40,6 +41,7 @@ struct Config {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct Server {
     host: String,
     port: u16,

--- a/examples/serde_path_to_error.rs
+++ b/examples/serde_path_to_error.rs
@@ -17,11 +17,13 @@
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct Config {
     server: Server,
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct Server {
     host: String,
     port: u16,

--- a/examples/serde_path_to_error.rs
+++ b/examples/serde_path_to_error.rs
@@ -1,0 +1,53 @@
+/*
+  ----
+  Show how to enrich YAML deserialization errors with a Serde *path* using
+  the `serde_path_to_error` crate.
+
+  Why?
+  ------------------------
+  When parsing nested config structures, a type mismatch error like
+  "invalid type: string \"oops\", expected u16" is hard to act on without
+  knowing *where* it happened. `serde_path_to_error` wraps a Serde deserializer and
+  records the access path so you can report it alongside the underlying error.
+
+  While serde-saphyr has its own diagnostics, this expample shows how to use serde-saphyr
+  deserializer with `serde_path_to_error`.
+*/
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Config {
+    server: Server,
+}
+
+#[derive(Debug, Deserialize)]
+struct Server {
+    host: String,
+    port: u16,
+}
+
+fn main() {
+    // `port` is intentionally invalid: it's a string but we expect `u16`.
+    let yaml = r#"
+        server:
+          host: localhost
+          port: "oops"
+    "#;
+
+    let res: Result<Config, serde_saphyr::Error> = serde_saphyr::with_deserializer_from_str(yaml, |de| {
+        match serde_path_to_error::deserialize::<_, Config>(de) {
+            Ok(v) => Ok(v),
+            Err(e) => Err(<serde_saphyr::Error as serde::de::Error>::custom(format!(
+                "deserialization error at {}: {}",
+                e.path(),
+                e
+            ))),
+        }
+    });
+
+    match res {
+        Ok(cfg) => println!("Parsed config: {cfg:?}"),
+        Err(e) => eprintln!("{e}"),
+    }
+}

--- a/examples/transcoding.rs
+++ b/examples/transcoding.rs
@@ -1,0 +1,71 @@
+/*
+  In Serde terms, *transcoding* means:
+    - deserialize from one format (JSON)
+    - immediately serialize into another format (YAML)
+    - without building a Rust struct/enum in the middle
+
+  Why?
+  ----------------------
+  - You have data in JSON and want to emit YAML.
+  - You want to preserve the general structure without writing a schema.
+  - You want streaming behavior (in general). In this particular example we
+    use `from_str` for simplicity, but the same approach works with readers.
+
+  How?
+  -------------------------
+  1) `serde_json::Deserializer` reads JSON and produces Serde "events".
+  2) `serde_saphyr::Serializer` consumes the same events and writes YAML.
+  3) `serde_transcode::transcode` connects the two.
+
+  Serde is the common language in the middle.
+  We are not converting JSON -> `serde_json::Value` -> YAML.
+*/
+
+fn main() {
+    let json = r#"
+        {
+            "rainbow": ["red", "orange", "yellow", "green", "blue", "purple"],
+            "point": {
+                "x": 12,
+                "y": -34
+            },
+            "bools": [true, false]
+        }
+    "#;
+
+    // JSON deserializer:
+    //
+    // `serde_json::Deserializer` implements Serde's `Deserializer` trait, which
+    // yields the data in a generic way (maps, sequences, strings, numbers, ...).
+    let mut json_deserializer = serde_json::Deserializer::from_str(json);
+
+    // YAML serializer:
+    //
+    // `serde_saphyr::Serializer` implements Serde's `Serializer` trait and
+    // writes YAML into any `fmt::Write` target (here: a `String`).
+    let mut yaml = String::new();
+    let mut yaml_serializer = serde_saphyr::Serializer::new(&mut yaml);
+
+    // Bridge:
+    serde_transcode::transcode(&mut json_deserializer, &mut yaml_serializer)
+        .expect("transcoding JSON -> YAML must succeed for the sample input");
+
+    // Print the YAML so you can see the result.
+    //
+    // Expected output:
+    //
+    // rainbow:
+    //   - red
+    //   - orange
+    //   - yellow
+    //   - green
+    //   - blue
+    //   - purple
+    // point:
+    //   x: 12
+    //   y: -34
+    // bools:
+    //   - true
+    //   - false
+    print!("{yaml}");
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -32,6 +32,13 @@ use std::borrow::Cow;
 use std::collections::{HashSet, VecDeque};
 use std::mem;
 
+pub mod with_deserializer;
+pub use with_deserializer::{
+    with_deserializer_from_reader, with_deserializer_from_reader_with_options,
+    with_deserializer_from_slice, with_deserializer_from_slice_with_options,
+    with_deserializer_from_str, with_deserializer_from_str_with_options,
+};
+
 type FastHashSet<T> = HashSet<T, RandomState>;
 
 mod spanned_deser;

--- a/src/de/spanned_deser.rs
+++ b/src/de/spanned_deser.rs
@@ -5,14 +5,15 @@
 
 use serde::de::{self, IntoDeserializer, Visitor};
 
-use super::{Cfg, Deser, Error, Events, Location};
+use super::{Cfg, Error, Events, Location};
+use crate::YamlDeserializer;
 
 /// Dispatch for the internal `__yaml_spanned` newtype.
 ///
 /// This captures the current *use-site* (`referenced`) and *definition-site*
 /// (`defined`) locations and then synthesizes a struct-like view:
 /// `{ value: T, referenced: Location, defined: Location }`.
-pub(super) fn deserialize_yaml_spanned<'de, V>(de: Deser<'_>, visitor: V) -> Result<V::Value, Error>
+pub(super) fn deserialize_yaml_spanned<'de, V>(de: YamlDeserializer<'_>, visitor: V) -> Result<V::Value, Error>
 where
     V: Visitor<'de>,
 {
@@ -50,7 +51,7 @@ where
 ///   *reborrow* `&mut dyn Events` from inside `Deser` rather than moving it out.
 struct SpannedDeser<'a> {
     /// The underlying YAML deserializer we delegate `value: T` to.
-    de: Deser<'a>,
+    de: YamlDeserializer<'a>,
     /// Use-site location: where the next node is referenced (e.g. `*a` token).
     referenced: Location,
     /// Definition-site location: where the node is defined (e.g. anchored scalar).
@@ -99,7 +100,7 @@ impl<'de> de::Deserializer<'de> for SpannedDeser<'_> {
 /// struct (`Repr`) with named fields.
 struct SpannedMapAccess<'a> {
     /// Underlying YAML deserializer.
-    de: Deser<'a>,
+    de: YamlDeserializer<'a>,
     /// Use-site location (see [`Events::reference_location`]).
     referenced: Location,
     /// Definition-site location (typically `Ev::location()` from `peek()`).
@@ -133,7 +134,7 @@ impl<'de> de::MapAccess<'de> for SpannedMapAccess<'_> {
             1 => {
                 // value
                 // Reborrow the event source instead of moving `&mut` out of `self.de`.
-                seed.deserialize(Deser::new(&mut *self.de.ev, self.de.cfg))
+                seed.deserialize(YamlDeserializer::new(&mut *self.de.ev, self.de.cfg))
             }
             2 => {
                 // referenced

--- a/src/de/with_deserializer.rs
+++ b/src/de/with_deserializer.rs
@@ -1,0 +1,184 @@
+use crate::budget::EnforcingPolicy;
+use crate::live_events::LiveEvents;
+
+use super::{Cfg, Error, Events, Options, YamlDeserializer};
+
+fn normalize_str_input(input: &str) -> &str {
+    // Normalize: ignore a single leading UTF-8 BOM if present.
+    input.strip_prefix('\u{FEFF}').unwrap_or(input)
+}
+
+fn deserialize_with_scope<R, F, W>(
+    src: &mut LiveEvents,
+    cfg: Cfg,
+    f: F,
+    wrap_err: W,
+) -> Result<R, Error>
+where
+    for<'de> F: FnOnce(crate::Deserializer<'de>) -> Result<R, Error>,
+    W: Fn(Error) -> Error,
+{
+    let value_res = crate::anchor_store::with_document_scope(|| f(YamlDeserializer::new(src, cfg)));
+    match value_res {
+        Ok(v) => Ok(v),
+        Err(e) => {
+            if src.synthesized_null_emitted() {
+                // If the only thing in the input was an empty document (synthetic null),
+                // surface this as an EOF error to preserve expected error semantics
+                // for incompatible target types (e.g., bool).
+                Err(wrap_err(Error::eof().with_location(src.last_location())))
+            } else {
+                Err(wrap_err(e))
+            }
+        }
+    }
+}
+
+fn enforce_single_document_and_finish<W>(
+    src: &mut LiveEvents,
+    multiple_docs_msg: &'static str,
+    wrap_err: W,
+) -> Result<(), Error>
+where
+    W: Fn(Error) -> Error,
+{
+    // After finishing first document, peek ahead to detect either another document/content
+    // or trailing garbage. If a scan error occurs but we have seen a DocumentEnd ("..."),
+    // ignore the trailing garbage. Otherwise, surface the error.
+    match src.peek() {
+        Ok(Some(_)) => {
+            return Err(wrap_err(
+                Error::msg(multiple_docs_msg).with_location(src.last_location()),
+            ));
+        }
+        Ok(None) => {}
+        Err(e) => {
+            if src.seen_doc_end() {
+                // Trailing garbage after a proper document end marker is ignored.
+            } else {
+                return Err(wrap_err(e));
+            }
+        }
+    }
+
+    src.finish().map_err(wrap_err)
+}
+
+/// Create a streaming [`crate::Deserializer`] for a YAML string and run a closure against it.
+///
+/// This is useful for tooling that needs access to the underlying Serde deserializer,
+/// such as wrappers that report unknown/ignored fields (e.g. the `serde_ignored` crate)
+/// or wrappers that augment error paths.
+///
+/// The deserializer borrows internal parsing state, so it cannot be returned directly.
+/// Instead, you provide a closure `f` that performs the desired deserialization.
+pub fn with_deserializer_from_str_with_options<R, F>(
+    input: &str,
+    options: Options,
+    f: F,
+) -> Result<R, Error>
+where
+    for<'de> F: FnOnce(crate::Deserializer<'de>) -> Result<R, Error>,
+{
+    let input = normalize_str_input(input);
+
+    let with_snippet = options.with_snippet;
+    let crop_radius = options.crop_radius;
+
+    let cfg = Cfg::from_options(&options);
+    // Do not stop at DocumentEnd; we'll probe for trailing content/errors explicitly.
+    let mut src = LiveEvents::from_str(
+        input,
+        options.budget,
+        options.budget_report,
+        options.alias_limits,
+        false,
+    );
+
+    let wrap_err = |e| crate::maybe_with_snippet(e, input, with_snippet, crop_radius);
+
+    let value = deserialize_with_scope(&mut src, cfg, f, wrap_err)?;
+    enforce_single_document_and_finish(
+        &mut src,
+        "multiple YAML documents detected; use from_multiple or from_multiple_with_options",
+        wrap_err,
+    )?;
+    Ok(value)
+}
+
+/// Convenience wrapper around [`with_deserializer_from_str_with_options`] using
+/// [`Options::default`].
+pub fn with_deserializer_from_str<R, F>(input: &str, f: F) -> Result<R, Error>
+where
+    for<'de> F: FnOnce(crate::Deserializer<'de>) -> Result<R, Error>,
+{
+    with_deserializer_from_str_with_options(input, Options::default(), f)
+}
+
+/// Create a streaming [`crate::Deserializer`] for a UTF-8 byte slice and run a closure against it.
+///
+/// This is equivalent to [`with_deserializer_from_str`], but validates the input is UTF-8.
+pub fn with_deserializer_from_slice<R, F>(bytes: &[u8], f: F) -> Result<R, Error>
+where
+    for<'de> F: FnOnce(crate::Deserializer<'de>) -> Result<R, Error>,
+{
+    with_deserializer_from_slice_with_options(bytes, Options::default(), f)
+}
+
+/// Create a streaming [`crate::Deserializer`] for a UTF-8 byte slice with configurable [`Options`]
+/// and run a closure against it.
+pub fn with_deserializer_from_slice_with_options<R, F>(
+    bytes: &[u8],
+    options: Options,
+    f: F,
+) -> Result<R, Error>
+where
+    for<'de> F: FnOnce(crate::Deserializer<'de>) -> Result<R, Error>,
+{
+    let s = std::str::from_utf8(bytes).map_err(|_| Error::msg("input is not valid UTF-8"))?;
+    with_deserializer_from_str_with_options(s, options, f)
+}
+
+/// Create a streaming [`crate::Deserializer`] for any [`std::io::Read`] and run a closure against it.
+///
+/// This is the reader-based counterpart to [`with_deserializer_from_str`]. It consumes a
+/// byte-oriented reader, decodes it to UTF-8, and streams events into the deserializer.
+pub fn with_deserializer_from_reader<R, Out, F>(reader: R, f: F) -> Result<Out, Error>
+where
+    R: std::io::Read,
+    for<'de> F: FnOnce(crate::Deserializer<'de>) -> Result<Out, Error>,
+{
+    with_deserializer_from_reader_with_options(reader, Options::default(), f)
+}
+
+/// Create a streaming [`crate::Deserializer`] for any [`std::io::Read`] with configurable [`Options`]
+/// and run a closure against it.
+pub fn with_deserializer_from_reader_with_options<R, Out, F>(
+    reader: R,
+    options: Options,
+    f: F,
+) -> Result<Out, Error>
+where
+    R: std::io::Read,
+    for<'de> F: FnOnce(crate::Deserializer<'de>) -> Result<Out, Error>,
+{
+    let cfg = Cfg::from_options(&options);
+    let mut src = LiveEvents::from_reader(
+        reader,
+        options.budget,
+        options.budget_report,
+        options.alias_limits,
+        false,
+        EnforcingPolicy::AllContent,
+    );
+
+    let wrap_err = |e| e;
+
+    let value = deserialize_with_scope(&mut src, cfg, f, wrap_err)?;
+    enforce_single_document_and_finish(
+        &mut src,
+        "multiple YAML documents detected; use read or read_with_options to obtain the iterator",
+        wrap_err,
+    )?;
+    Ok(value)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,13 +29,15 @@ mod de_snipped;
 mod live_events;
 pub mod options;
 mod parse_scalars;
-mod ser;
+pub mod ser;
 mod spanned;
 
 #[cfg(feature = "garde")]
 pub mod path_map;
 
 pub mod ser_error;
+
+pub use ser::YamlSer;
 
 mod serializer_options;
 mod tags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 /// Serialization public API is defined at crate root
+
 pub use anchors::{ArcAnchor, ArcWeakAnchor, RcAnchor, RcWeakAnchor};
 pub use de::{Budget, DuplicateKeyPolicy, Error, Options};
 pub use location::Location;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 /// Serialization public API is defined at crate root
-
 pub use anchors::{ArcAnchor, ArcWeakAnchor, RcAnchor, RcWeakAnchor};
 pub use de::{Budget, DuplicateKeyPolicy, Error, Options};
 pub use location::Location;
@@ -39,6 +38,12 @@ pub mod ser_error;
 
 pub use ser::YamlSerializer as Serializer;
 pub use de::YamlDeserializer as Deserializer;
+
+pub use de::{
+    with_deserializer_from_reader, with_deserializer_from_reader_with_options,
+    with_deserializer_from_slice, with_deserializer_from_slice_with_options,
+    with_deserializer_from_str, with_deserializer_from_str_with_options,
+};
 
 mod serializer_options;
 mod tags;
@@ -751,7 +756,12 @@ where
     }
 }
 
-fn maybe_with_snippet(err: Error, input: &str, with_snippet: bool, crop_radius: usize) -> Error {
+pub(crate) fn maybe_with_snippet(
+    err: Error,
+    input: &str,
+    with_snippet: bool,
+    crop_radius: usize,
+) -> Error {
     if with_snippet && crop_radius > 0 && err.location().is_some() {
         err.with_snippet(input, crop_radius)
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@ pub mod path_map;
 
 pub mod ser_error;
 
-pub use ser::YamlSer;
+pub use ser::YamlSerializer;
+pub use de::YamlDeserializer;
 
 mod serializer_options;
 mod tags;
@@ -81,7 +82,7 @@ pub fn to_writer<W: std::fmt::Write, T: serde::Serialize>(
     output: &mut W,
     value: &T,
 ) -> std::result::Result<(), crate::ser::Error> {
-    let mut ser = crate::ser::YamlSer::new(output);
+    let mut ser = crate::ser::YamlSerializer::new(output);
     value.serialize(&mut ser)
 }
 
@@ -109,7 +110,7 @@ pub fn to_fmt_writer_with_options<W: std::fmt::Write, T: serde::Serialize>(
     mut options: SerializerOptions,
 ) -> std::result::Result<(), crate::ser::Error> {
     options.consistent()?;
-    let mut ser = crate::ser::YamlSer::with_options(output, &mut options);
+    let mut ser = crate::ser::YamlSerializer::with_options(output, &mut options);
     value.serialize(&mut ser)
 }
 
@@ -143,7 +144,7 @@ pub fn to_io_writer_with_options<W: std::io::Write, T: serde::Serialize>(
         output,
         last_err: None,
     };
-    let mut ser = crate::ser::YamlSer::with_options(&mut adapter, &mut options);
+    let mut ser = crate::ser::YamlSerializer::with_options(&mut adapter, &mut options);
     match value.serialize(&mut ser) {
         Ok(()) => Ok(()),
         Err(e) => {
@@ -255,7 +256,7 @@ pub fn from_str_with_options<T: DeserializeOwned>(
         false,
     );
     let value_res = crate::anchor_store::with_document_scope(|| {
-        T::deserialize(crate::de::Deser::new(&mut src, cfg))
+        T::deserialize(crate::de::YamlDeserializer::new(&mut src, cfg))
     });
     let value = match value_res {
         Ok(v) => v,
@@ -327,7 +328,7 @@ fn from_str_with_options_and_path_recorder<T: DeserializeOwned>(
     let mut recorder = crate::path_map::PathRecorder::new();
 
     let value_res = crate::anchor_store::with_document_scope(|| {
-        T::deserialize(crate::de::Deser::new_with_path_recorder(
+        T::deserialize(crate::de::YamlDeserializer::new_with_path_recorder(
             &mut src,
             cfg,
             &mut recorder,
@@ -455,7 +456,7 @@ where
             Some(_) => {
                 let mut recorder = crate::path_map::PathRecorder::new();
                 let value_res = crate::anchor_store::with_document_scope(|| {
-                    T::deserialize(crate::de::Deser::new_with_path_recorder(
+                    T::deserialize(crate::de::YamlDeserializer::new_with_path_recorder(
                         &mut src,
                         cfg,
                         &mut recorder,
@@ -580,7 +581,7 @@ where
     let mut recorder = crate::path_map::PathRecorder::new();
 
     let value_res = crate::anchor_store::with_document_scope(|| {
-        T::deserialize(crate::de::Deser::new_with_path_recorder(
+        T::deserialize(crate::de::YamlDeserializer::new_with_path_recorder(
             &mut src,
             cfg,
             &mut recorder,
@@ -687,7 +688,7 @@ where
                     Ok(Some(_)) => {
                         let mut recorder = crate::path_map::PathRecorder::new();
                         let value_res = crate::anchor_store::with_document_scope(|| {
-                            T::deserialize(crate::de::Deser::new_with_path_recorder(
+                            T::deserialize(crate::de::YamlDeserializer::new_with_path_recorder(
                                 &mut self.src,
                                 self.cfg,
                                 &mut recorder,
@@ -863,7 +864,7 @@ pub fn from_multiple_with_options<T: DeserializeOwned>(
             }
             Some(_) => {
                 let value_res = crate::anchor_store::with_document_scope(|| {
-                    T::deserialize(crate::de::Deser::new(&mut src, cfg))
+                    T::deserialize(crate::de::YamlDeserializer::new(&mut src, cfg))
                 });
                 let value = match value_res {
                     Ok(v) => v,
@@ -1153,7 +1154,7 @@ pub fn from_reader_with_options<'a, R: std::io::Read + 'a, T: DeserializeOwned>(
         EnforcingPolicy::AllContent,
     );
     let value_res = crate::anchor_store::with_document_scope(|| {
-        T::deserialize(crate::de::Deser::new(&mut src, cfg))
+        T::deserialize(crate::de::YamlDeserializer::new(&mut src, cfg))
     });
     let value = match value_res {
         Ok(v) => v,
@@ -1375,7 +1376,7 @@ where
                     }
                     Ok(Some(_)) => {
                         let res = crate::anchor_store::with_document_scope(|| {
-                            T::deserialize(crate::de::Deser::new(&mut self.src, self.cfg))
+                            T::deserialize(crate::de::YamlDeserializer::new(&mut self.src, self.cfg))
                         });
                         return Some(res);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ pub mod path_map;
 
 pub mod ser_error;
 
-pub use ser::YamlSerializer;
-pub use de::YamlDeserializer;
+pub use ser::YamlSerializer as Serializer;
+pub use de::YamlDeserializer as Deserializer;
 
 mod serializer_options;
 mod tags;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -455,7 +455,7 @@ pub struct YamlSerializer<'a, W: Write> {
 }
 
 impl<'a, W: Write> YamlSerializer<'a, W> {
-    /// Construct a `YamlSer` that writes to `out`.
+    /// Construct a `YamlSerializer` that writes to `out`.
     /// Called by `to_writer`/`to_string` entry points.
     pub fn new(out: &'a mut W) -> Self {
         Self {
@@ -485,14 +485,14 @@ impl<'a, W: Write> YamlSerializer<'a, W> {
             pending_str_from_auto: false,
         }
     }
-    /// Construct a `YamlSer` with a specific indentation step.
+    /// Construct a `YamlSerializer` with a specific indentation step.
     /// Typically used internally by tests or convenience wrappers.
     pub fn with_indent(out: &'a mut W, indent_step: usize) -> Self {
         let mut s = Self::new(out);
         s.indent_step = indent_step;
         s
     }
-    /// Construct a `YamlSer` from user-supplied [`SerializerOptions`].
+    /// Construct a `YamlSerializer` from user-supplied [`SerializerOptions`].
     /// Used by `to_writer_with_options`.
     pub fn with_options(out: &'a mut W, options: &mut SerializerOptions) -> Self {
         let mut s = Self::new(out);
@@ -822,7 +822,7 @@ impl<'a, W: Write> YamlSerializer<'a, W> {
 }
 
 // ------------------------------------------------------------
-// Impl Serializer for YamlSer
+// Impl Serializer for YamlSerializer
 // ------------------------------------------------------------
 
 impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
@@ -1522,7 +1522,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
 
 /// Serializer for sequences and tuples.
 ///
-/// Created by `YamlSer::serialize_seq`/`serialize_tuple`. Holds a mutable
+/// Created by `YamlSerializer::serialize_seq`/`serialize_tuple`. Holds a mutable
 /// reference to the parent serializer and formatting state for the sequence.
 pub struct SeqSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.
@@ -1851,7 +1851,7 @@ impl<'a, 'b, W: Write> SerializeTupleStruct for TupleSer<'a, 'b, W> {
 // Tuple variant (enum Variant: ( ... ))
 /// Serializer for tuple variants (enum Variant: ( ... )).
 ///
-/// Created by `YamlSer::serialize_tuple_variant` to emit the variant name
+/// Created by `YamlSerializer::serialize_tuple_variant` to emit the variant name
 /// followed by a block sequence of fields.
 pub struct TupleVariantSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.
@@ -1880,7 +1880,7 @@ impl<'a, 'b, W: Write> SerializeTupleVariant for TupleVariantSer<'a, 'b, W> {
 
 /// Serializer for maps and structs.
 ///
-/// Created by `YamlSer::serialize_map`/`serialize_struct`. Manages indentation
+/// Created by `YamlSerializer::serialize_map`/`serialize_struct`. Manages indentation
 /// and flow/block style for key-value pairs.
 pub struct MapSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.
@@ -2092,7 +2092,7 @@ impl<'a, 'b, W: Write> SerializeStruct for MapSer<'a, 'b, W> {
 
 /// Serializer for struct variants (enum Variant: { ... }).
 ///
-/// Created by `YamlSer::serialize_struct_variant` to emit the variant name
+/// Created by `YamlSerializer::serialize_struct_variant` to emit the variant name
 /// followed by a block mapping of fields.
 pub struct StructVariantSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -392,6 +392,27 @@ type AnchorId = u32;
 ///
 /// This type implements `serde::Serializer` and writes YAML to a `fmt::Write`.
 /// It manages indentation, flow/block styles, and YAML anchors/aliases.
+///
+/// This type is also re-exported from the crate root as [`serde_saphyr::Serializer`].
+///
+/// ## Example
+///
+/// ```rust
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct Foo {
+///     a: i32,
+///     b: bool,
+/// }
+///
+/// let mut out = String::new();
+/// let mut ser = serde_saphyr::Serializer::new(&mut out);
+/// Foo { a: 1, b: true }.serialize(&mut ser)?;
+///
+/// assert!(out.contains("a: 1"));
+/// # Ok::<(), serde_saphyr::ser::Error>(())
+/// ```
 pub struct YamlSerializer<'a, W: Write> {
     /// Destination writer where YAML text is emitted.
     out: &'a mut W,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -392,7 +392,7 @@ type AnchorId = u32;
 ///
 /// This type implements `serde::Serializer` and writes YAML to a `fmt::Write`.
 /// It manages indentation, flow/block styles, and YAML anchors/aliases.
-pub struct YamlSer<'a, W: Write> {
+pub struct YamlSerializer<'a, W: Write> {
     /// Destination writer where YAML text is emitted.
     out: &'a mut W,
     /// Spaces per indentation level for block-style collections.
@@ -454,7 +454,7 @@ pub struct YamlSer<'a, W: Write> {
     current_map_depth: Option<usize>,
 }
 
-impl<'a, W: Write> YamlSer<'a, W> {
+impl<'a, W: Write> YamlSerializer<'a, W> {
     /// Construct a `YamlSer` that writes to `out`.
     /// Called by `to_writer`/`to_string` entry points.
     pub fn new(out: &'a mut W) -> Self {
@@ -825,7 +825,7 @@ impl<'a, W: Write> YamlSer<'a, W> {
 // Impl Serializer for YamlSer
 // ------------------------------------------------------------
 
-impl<'a, 'b, W: Write> Serializer for &'a mut YamlSer<'b, W> {
+impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
     type Ok = ();
     type Error = Error;
 
@@ -1526,7 +1526,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSer<'b, W> {
 /// reference to the parent serializer and formatting state for the sequence.
 pub struct SeqSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.
-    ser: &'a mut YamlSer<'b, W>,
+    ser: &'a mut YamlSerializer<'b, W>,
     /// Target indentation depth for block-style items.
     depth: usize,
     /// Whether the sequence is being written in flow style (`[a, b]`).
@@ -1633,7 +1633,7 @@ impl<'a, 'b, W: Write> SerializeSeq for SeqSer<'a, 'b, W> {
 /// - Internal weak-anchor payloads (`__yaml_weak_anchor`).
 pub struct TupleSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.
-    ser: &'a mut YamlSer<'b, W>,
+    ser: &'a mut YamlSerializer<'b, W>,
     /// Variant describing how to interpret fields.
     kind: TupleKind,
     /// Current field index being serialized.
@@ -1662,7 +1662,7 @@ enum TupleKind {
 }
 impl<'a, 'b, W: Write> TupleSer<'a, 'b, W> {
     /// Create a tuple serializer for normal tuple-structs.
-    fn normal(ser: &'a mut YamlSer<'b, W>) -> Self {
+    fn normal(ser: &'a mut YamlSerializer<'b, W>) -> Self {
         let depth_next = ser.depth + 1;
         Self {
             ser,
@@ -1677,7 +1677,7 @@ impl<'a, 'b, W: Write> TupleSer<'a, 'b, W> {
         }
     }
     /// Create a tuple serializer for internal strong-anchor payloads.
-    fn anchor_strong(ser: &'a mut YamlSer<'b, W>) -> Self {
+    fn anchor_strong(ser: &'a mut YamlSerializer<'b, W>) -> Self {
         Self {
             ser,
             kind: TupleKind::AnchorStrong,
@@ -1691,7 +1691,7 @@ impl<'a, 'b, W: Write> TupleSer<'a, 'b, W> {
         }
     }
     /// Create a tuple serializer for internal weak-anchor payloads.
-    fn anchor_weak(ser: &'a mut YamlSer<'b, W>) -> Self {
+    fn anchor_weak(ser: &'a mut YamlSerializer<'b, W>) -> Self {
         Self {
             ser,
             kind: TupleKind::AnchorWeak,
@@ -1705,7 +1705,7 @@ impl<'a, 'b, W: Write> TupleSer<'a, 'b, W> {
         }
     }
     /// Create a tuple serializer for internal commented wrapper.
-    fn commented(ser: &'a mut YamlSer<'b, W>) -> Self {
+    fn commented(ser: &'a mut YamlSerializer<'b, W>) -> Self {
         Self {
             ser,
             kind: TupleKind::Commented,
@@ -1855,7 +1855,7 @@ impl<'a, 'b, W: Write> SerializeTupleStruct for TupleSer<'a, 'b, W> {
 /// followed by a block sequence of fields.
 pub struct TupleVariantSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.
-    ser: &'a mut YamlSer<'b, W>,
+    ser: &'a mut YamlSerializer<'b, W>,
     /// Target indentation depth for the fields.
     depth: usize,
 }
@@ -1884,7 +1884,7 @@ impl<'a, 'b, W: Write> SerializeTupleVariant for TupleVariantSer<'a, 'b, W> {
 /// and flow/block style for key-value pairs.
 pub struct MapSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.
-    ser: &'a mut YamlSer<'b, W>,
+    ser: &'a mut YamlSerializer<'b, W>,
     /// Target indentation depth for block-style entries.
     depth: usize,
     /// Whether the mapping is in flow style (`{k: v}`).
@@ -2096,7 +2096,7 @@ impl<'a, 'b, W: Write> SerializeStruct for MapSer<'a, 'b, W> {
 /// followed by a block mapping of fields.
 pub struct StructVariantSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.
-    ser: &'a mut YamlSer<'b, W>,
+    ser: &'a mut YamlSerializer<'b, W>,
     /// Target indentation depth for the fields.
     depth: usize,
 }

--- a/tests/transcode_from_json.rs
+++ b/tests/transcode_from_json.rs
@@ -1,6 +1,15 @@
 #[cfg(test)]
 mod tests {
+    use serde::Deserialize;
     use serde_saphyr::SerializerOptions;
+
+    fn transcode_yaml_to_json(yaml: &str) -> String {
+        serde_saphyr::with_deserializer_from_str(yaml, |de| {
+            let v = serde_json::Value::deserialize(de)?;
+            serde_json::to_string(&v).map_err(|e| serde::de::Error::custom(e.to_string()))
+        })
+        .unwrap()
+    }
 
     fn assert_json_eq(actual_json: &str, expected_json: &str) {
         let actual: serde_json::Value = serde_json::from_str(actual_json).unwrap();
@@ -125,8 +134,7 @@ bools:
   - false
 "#;
 
-        let v: serde_json::Value = serde_saphyr::from_str(yaml).unwrap();
-        let json = serde_json::to_string(&v).unwrap();
+        let json = transcode_yaml_to_json(yaml);
 
         assert_json_eq(
             &json,
@@ -163,8 +171,7 @@ bools:
     self-describing: true
 "#;
 
-        let v: serde_json::Value = serde_saphyr::from_str(yaml).unwrap();
-        let json = serde_json::to_string(&v).unwrap();
+        let json = transcode_yaml_to_json(yaml);
 
         assert_json_eq(
             &json,

--- a/tests/transcode_from_json.rs
+++ b/tests/transcode_from_json.rs
@@ -18,7 +18,7 @@ mod tests {
         let mut json_deserializer = serde_json::Deserializer::from_str(json);
 
         let mut yaml = String::new();
-        let mut yaml_serializer = serde_saphyr::YamlSerializer::new(&mut yaml);
+        let mut yaml_serializer = serde_saphyr::Serializer::new(&mut yaml);
         serde_transcode::transcode(&mut json_deserializer, &mut yaml_serializer).unwrap();
 
         assert_eq!(
@@ -72,7 +72,7 @@ bools:
             ..Default::default()
         };
         let mut yaml_serializer =
-            serde_saphyr::YamlSerializer::with_options(&mut yaml, &mut yaml_serializer_options);
+            serde_saphyr::Serializer::with_options(&mut yaml, &mut yaml_serializer_options);
         serde_transcode::transcode(&mut json_deserializer, &mut yaml_serializer).unwrap();
 
         assert_eq!(

--- a/tests/transcode_from_json.rs
+++ b/tests/transcode_from_json.rs
@@ -18,7 +18,7 @@ mod tests {
         let mut json_deserializer = serde_json::Deserializer::from_str(json);
 
         let mut yaml = String::new();
-        let mut yaml_serializer = serde_saphyr::YamlSer::new(&mut yaml);
+        let mut yaml_serializer = serde_saphyr::YamlSerializer::new(&mut yaml);
         serde_transcode::transcode(&mut json_deserializer, &mut yaml_serializer).unwrap();
 
         assert_eq!(
@@ -72,7 +72,7 @@ bools:
             ..Default::default()
         };
         let mut yaml_serializer =
-            serde_saphyr::YamlSer::with_options(&mut yaml, &mut yaml_serializer_options);
+            serde_saphyr::YamlSerializer::with_options(&mut yaml, &mut yaml_serializer_options);
         serde_transcode::transcode(&mut json_deserializer, &mut yaml_serializer).unwrap();
 
         assert_eq!(

--- a/tests/transcode_from_json.rs
+++ b/tests/transcode_from_json.rs
@@ -2,6 +2,12 @@
 mod tests {
     use serde_saphyr::SerializerOptions;
 
+    fn assert_json_eq(actual_json: &str, expected_json: &str) {
+        let actual: serde_json::Value = serde_json::from_str(actual_json).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        assert_eq!(actual, expected);
+    }
+
     #[test]
     fn from_sample_platter_json_to_yaml_without_options() {
         let json = r#"
@@ -99,6 +105,88 @@ bools:
       - Language
     self-describing: true
 "#
+        );
+    }
+
+    #[test]
+    fn from_sample_platter_yaml_to_json() {
+        let yaml = r#"rainbow:
+  - red
+  - orange
+  - yellow
+  - green
+  - blue
+  - purple
+point:
+  x: 12
+  y: -34
+bools:
+  - true
+  - false
+"#;
+
+        let v: serde_json::Value = serde_saphyr::from_str(yaml).unwrap();
+        let json = serde_json::to_string(&v).unwrap();
+
+        assert_json_eq(
+            &json,
+            r#"{
+              "rainbow": ["red", "orange", "yellow", "green", "blue", "purple"],
+              "point": {"x": 12, "y": -34},
+              "bools": [true, false]
+            }"#,
+        );
+    }
+
+    #[test]
+    fn from_nested_yaml_to_json() {
+        let yaml = r#"formats:
+  - name: CBOR
+    deacronymization:
+      - Concise
+      - Binary
+      - Object
+      - Representation
+    self-describing: false
+  - name: JSON
+    deacronymization:
+      - JavaScript
+      - Object
+      - Notation
+    self-describing: true
+  - name: YAML
+    deacronymization:
+      - YAML
+      - Ain't
+      - Markup
+      - Language
+    self-describing: true
+"#;
+
+        let v: serde_json::Value = serde_saphyr::from_str(yaml).unwrap();
+        let json = serde_json::to_string(&v).unwrap();
+
+        assert_json_eq(
+            &json,
+            r#"{
+              "formats": [
+                {
+                  "name": "CBOR",
+                  "deacronymization": ["Concise", "Binary", "Object", "Representation"],
+                  "self-describing": false
+                },
+                {
+                  "name": "JSON",
+                  "deacronymization": ["JavaScript", "Object", "Notation"],
+                  "self-describing": true
+                },
+                {
+                  "name": "YAML",
+                  "deacronymization": ["YAML", "Ain't", "Markup", "Language"],
+                  "self-describing": true
+                }
+              ]
+            }"#,
         );
     }
 }

--- a/tests/transcode_from_json.rs
+++ b/tests/transcode_from_json.rs
@@ -77,7 +77,7 @@ bools:
 
         assert_eq!(
             yaml,
-            // NOTE: serde_saphyr can't parse the output this resulted yet
+            // NOTE: serde_saphyr can't parse this yet; this will need to be changed after a fix for #31 is incorporated
             r#"formats:
        - name: CBOR
               deacronymization:

--- a/tests/transcode_from_json.rs
+++ b/tests/transcode_from_json.rs
@@ -1,0 +1,105 @@
+#[cfg(test)]
+mod tests {
+    use serde_saphyr::SerializerOptions;
+
+    #[test]
+    fn from_sample_platter_json_to_yaml_without_options() {
+        let json = r#"
+            {
+                "rainbow": ["red", "orange", "yellow", "green", "blue", "purple"],
+                "point": {
+                    "x": 12,
+                    "y": -34
+                },
+                "bools": [true, false]
+            }
+        "#;
+
+        let mut json_deserializer = serde_json::Deserializer::from_str(json);
+
+        let mut yaml = String::new();
+        let mut yaml_serializer = serde_saphyr::YamlSer::new(&mut yaml);
+        serde_transcode::transcode(&mut json_deserializer, &mut yaml_serializer).unwrap();
+
+        assert_eq!(
+            yaml,
+            r#"rainbow:
+  - red
+  - orange
+  - yellow
+  - green
+  - blue
+  - purple
+point:
+  x: 12
+  y: -34
+bools:
+  - true
+  - false
+"#
+        );
+    }
+
+    #[test]
+    fn from_nested_json_with_indent_step_option() {
+        let json = r#"
+            {
+                "formats": [
+                    {
+                        "name": "CBOR",
+                        "deacronymization": ["Concise", "Binary", "Object", "Representation"],
+                        "self-describing": false
+                    },
+                    {
+                        "name": "JSON",
+                        "deacronymization": ["JavaScript", "Object", "Notation"],
+                        "self-describing": true
+                    },
+                    {
+                        "name": "YAML",
+                        "deacronymization": ["YAML", "Ain't", "Markup", "Language"],
+                        "self-describing": true
+                    }
+                ]
+            }
+        "#;
+
+        let mut json_deserializer = serde_json::Deserializer::from_str(json);
+
+        let mut yaml = String::new();
+        let mut yaml_serializer_options = SerializerOptions {
+            indent_step: 7,
+            ..Default::default()
+        };
+        let mut yaml_serializer =
+            serde_saphyr::YamlSer::with_options(&mut yaml, &mut yaml_serializer_options);
+        serde_transcode::transcode(&mut json_deserializer, &mut yaml_serializer).unwrap();
+
+        assert_eq!(
+            yaml,
+            // NOTE: serde_saphyr can't parse the output this resulted yet
+            r#"formats:
+       - name: CBOR
+              deacronymization:
+                     - Concise
+                     - Binary
+                     - Object
+                     - Representation
+              self-describing: false
+       - name: JSON
+              deacronymization:
+                     - JavaScript
+                     - Object
+                     - Notation
+              self-describing: true
+       - name: YAML
+              deacronymization:
+                     - YAML
+                     - Ain't
+                     - Markup
+                     - Language
+              self-describing: true
+"#
+        );
+    }
+}

--- a/tests/transcode_from_json.rs
+++ b/tests/transcode_from_json.rs
@@ -68,7 +68,7 @@ bools:
 
         let mut yaml = String::new();
         let mut yaml_serializer_options = SerializerOptions {
-            indent_step: 7,
+            indent_step: 2,
             ..Default::default()
         };
         let mut yaml_serializer =
@@ -77,28 +77,27 @@ bools:
 
         assert_eq!(
             yaml,
-            // NOTE: serde_saphyr can't parse this yet; this will need to be changed after a fix for #31 is incorporated
             r#"formats:
-       - name: CBOR
-              deacronymization:
-                     - Concise
-                     - Binary
-                     - Object
-                     - Representation
-              self-describing: false
-       - name: JSON
-              deacronymization:
-                     - JavaScript
-                     - Object
-                     - Notation
-              self-describing: true
-       - name: YAML
-              deacronymization:
-                     - YAML
-                     - Ain't
-                     - Markup
-                     - Language
-              self-describing: true
+  - name: CBOR
+    deacronymization:
+      - Concise
+      - Binary
+      - Object
+      - Representation
+    self-describing: false
+  - name: JSON
+    deacronymization:
+      - JavaScript
+      - Object
+      - Notation
+    self-describing: true
+  - name: YAML
+    deacronymization:
+      - YAML
+      - Ain't
+      - Markup
+      - Language
+    self-describing: true
 "#
         );
     }


### PR DESCRIPTION
Today I checked out you pull request, fixed all merge conflicts and ran tests. It generally looks good. We can have Serializer and Deserializer like in JSON. Internally I renamed them YamlSerializer and YamlDeserializer, to avoid confusion where do they belong. Your test is actually working. I added tests for transcoding in another direction (YAML to JSON). Our shared work is now in https://github.com/bourumir-wyngs/serde-saphyr/pull/45 . I suggest to switch into that branch. You can make further changes if you think this would benefit from more contribution, or otherwise I will merge into master as the feature towards 0.0.13 in a few days.