### PR TITLE
Fix serialization of tiny and large floats

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -829,9 +829,18 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
         } else {
             let mut buf = zmij::Buffer::new();
             let s = buf.format(v);
-            if !s.contains('.') && !s.contains('e') && !s.contains('E') {
-                self.out.write_str(s)?;
-                self.out.write_str(".0")?;
+            if !s.contains('.') {
+                if let Some(exp_pos) = s.find('e').or_else(|| s.find('E')) {
+                    // Has exponent but no decimal: insert .0 before the e
+                    // "4e-6" -> "4.0e-6"
+                    self.out.write_str(&s[..exp_pos])?;
+                    self.out.write_str(".0")?;
+                    self.out.write_str(&s[exp_pos..])?;
+                } else {
+                    // No decimal and no exponent: append .0
+                    self.out.write_str(s)?;
+                    self.out.write_str(".0")?;
+                }
             } else {
                 self.out.write_str(s)?;
             }

--- a/tests/scientific_notation.rs
+++ b/tests/scientific_notation.rs
@@ -1,0 +1,26 @@
+#[test]
+fn serialize_small_float_scientific_notation() {
+    let value = 0.000004_f64;
+    let yaml = serde_saphyr::to_string(&value).unwrap();
+    assert_eq!(yaml.trim(), "4.0e-6");
+
+    let value = 4.5123456e-18_f64;
+    let yaml = serde_saphyr::to_string(&value).unwrap();
+    assert_eq!(yaml.trim(), "4.5123456e-18");
+}
+
+#[test]
+fn serialize_large_float_scientific_notation() {
+    let value = 40000000000000000000.0_f64;
+    let yaml = serde_saphyr::to_string(&value).unwrap();
+    assert_eq!(yaml.trim(), "4.0e+19");
+}
+
+#[test]
+fn roundtrip_floats() {
+    for original in [4.0e-6, 3.12e18, 17.4] {
+        let yaml = serde_saphyr::to_string(&original).unwrap();
+        let parsed: f64 = serde_saphyr::from_str(&yaml).unwrap();
+        assert_eq!(original, parsed);
+    }
+}


### PR DESCRIPTION
zmij would emit 4e-6 for tiny floats for example which isn't a valid YAML float so we have to fix it by appending a .0 before the exponent.

Using pyyaml to check:

```
>>> type(yaml.safe_load("4.0e-6"))
<class 'float'>
>>> type(yaml.safe_load("4e-6"))
<class 'str'>
>>> yaml.safe_load("4.0e-6")
4e-06
>>> yaml.safe_load("4e-6")
'4e-6'
```