### PR TITLE
Ensure numeric looking map string keys are emitted as strings

### DIFF
--- a/src/ser_quoting.rs
+++ b/src/ser_quoting.rs
@@ -19,9 +19,21 @@ pub(crate) fn is_plain_safe(s: &str) -> bool {
         return false;
     }
     let bytes = s.as_bytes();
-    if bytes[0].is_ascii_whitespace()
+    let b0 = bytes[0];
+
+    // Check if it looks like a number, don't allow plain for this
+    if b0.is_ascii_digit() || matches!(b0, b'+' | b'-' | b'.') {
+        if parse_int_signed::<i64>(s, "i64", Location::UNKNOWN, true).is_ok() {
+            return false;
+        }
+        if parse_yaml12_float::<f64>(s, Location::UNKNOWN, SfTag::Float, false).is_ok() {
+            return false;
+        }
+    }
+
+    if b0.is_ascii_whitespace()
         || matches!(
-            bytes[0],
+            b0,
             b'-' | b'?'
                 | b':'
                 | b'['


### PR DESCRIPTION
Right now a yaml like this:

```yaml
foo:
  "1": bar
  "2": baz
```

Would be parsed properly but re-emitting it would end up with:

```yaml
foo:
  1: bar
  2: baz
```

It doesn't really matter if you know you're going to be parsing those keys as strings which is probably why this went unnoticed so far, but for interoperability with other parsing libraries like pyyaml, it's crucial to not lose the type info.

Example from pyyaml:

```
>>> print(yaml.safe_dump({1: "foo", "2": "bar"}))
1: foo
'2': bar

>>> yaml.safe_load('{1: "foo", "2": "bar"}')
{1: 'foo', '2': 'bar'}
```