### PR TITLE
Remove regex as runtime dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ smallvec = {  version = ">= 1.0.0, < 1.16.0", optional = true }
 num-traits = { version = ">=0.2.0, <=0.2.19", optional = true }
 base64 = { version = ">=0.21.0, <=0.22.1", optional = true }
 zmij = { version = "1.0", optional = true }
-regex = { version = ">= 1.0, < 1.13", optional = true } # range tested
 nohash-hasher = { version = "0.2", optional = true }
 encoding_rs_io = { version = "0.1", optional = true }
 ahash = { version = "0.8", optional = true }
@@ -39,7 +38,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 default = ["serialize", "deserialize"]
 
 # Enables YAML serialization APIs.
-serialize = ["dep:base64", "dep:num-traits", "dep:zmij", "dep:regex", "dep:nohash-hasher"]
+serialize = ["dep:base64", "dep:num-traits", "dep:zmij", "dep:nohash-hasher"]
 
 # Enables YAML deserialization APIs.
 deserialize = ["dep:base64", "dep:num-traits", "dep:annotate-snippets", "dep:saphyr-parser", "dep:smallvec", "dep:encoding_rs_io", "dep:ahash"]
@@ -82,6 +81,7 @@ serde_repr = "0.1.20"
 anyhow = "1.0"
 chrono = "0.4"
 trybuild = "1.0"
+regex = ">= 1.0, < 1.13"
 
 serde-transcode = "1.1.1" # we only use in tests
 serde_ignored = "0.1"

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -1,6 +1,4 @@
 use crate::parse_scalars::parse_yaml11_bool;
-use regex::Regex;
-use std::sync::OnceLock;
 
 fn is_numeric_looking(s: &str) -> bool {
     // Match a broad set of YAML numeric tokens (integer / float) even if they would overflow
@@ -12,36 +10,23 @@ fn is_numeric_looking(s: &str) -> bool {
     // - Supports `0x`/`0o`/`0b` prefixes.
     // - Supports decimal scientific notation with or without a dot (e.g. `1e9`, `1.0e9`, `.5`).
     //
-    // Compiled once to avoid regex compile cost on hot path.
-    static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        Regex::new(
-            r"(?x)
-            ^[+-]?(?:
-                # Explicit radices
-                0x[0-9A-Fa-f_]+ |
-                0o[0-7_]+       |
-                0b[01_]+        |
-
-                # Decimal floats / integers
-                (?:
-                    # Float with dot: 1. , 1.0 , .5
-                    (?:[0-9][0-9_]*\.[0-9_]*|\.[0-9][0-9_]*)
-                    (?:[eE][+-]?[0-9][0-9_]*)?
-                |
-                    # Scientific without dot: 1e9
-                    [0-9][0-9_]*[eE][+-]?[0-9][0-9_]*
-                |
-                    # Plain integer: 123
-                    [0-9][0-9_]*
-                )
-            )$
-            ",
-        )
-        .expect("valid numeric-looking regex")
-    });
-
-    re.is_match(s)
+    if s.is_empty() {
+        return false;
+    }
+    let cleaned = s.replace('_', "");
+    if let Some(stripped) = cleaned.strip_prefix("0x").or_else(|| cleaned.strip_prefix("0X")) {
+        // Hex
+        !stripped.is_empty() && stripped.chars().all(|c| c.is_ascii_hexdigit())
+    } else if let Some(stripped) = cleaned.strip_prefix("0o").or_else(|| cleaned.strip_prefix("0O")) {
+        // Octal
+        !stripped.is_empty() && stripped.chars().all(|c| matches!(c, '0'..='7'))
+    } else if let Some(stripped) = cleaned.strip_prefix("0b").or_else(|| cleaned.strip_prefix("0B")) {
+        // Binary
+        !stripped.is_empty() && stripped.chars().all(|c| matches!(c, '0' | '1'))
+    } else {
+        // Decimal
+        cleaned.parse::<f64>().is_ok()
+    }
 }
 
 /// Returns true if `s` is a special YAML token or looks like a number/boolean,

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -14,22 +14,18 @@ fn is_numeric_looking(s: &str) -> bool {
         return false;
     }
     let cleaned = s.replace('_', "");
-    if let Some(stripped) = cleaned
-        .strip_prefix("0x")
-        .or_else(|| cleaned.strip_prefix("0X"))
-    {
+    let rest = if cleaned.starts_with('+') || cleaned.starts_with('-') {
+        &cleaned[1..]
+    } else {
+        &cleaned
+    };
+    if let Some(stripped) = rest.strip_prefix("0x").or_else(|| rest.strip_prefix("0X")) {
         // Hex
         !stripped.is_empty() && stripped.chars().all(|c| c.is_ascii_hexdigit())
-    } else if let Some(stripped) = cleaned
-        .strip_prefix("0o")
-        .or_else(|| cleaned.strip_prefix("0O"))
-    {
+    } else if let Some(stripped) = rest.strip_prefix("0o").or_else(|| rest.strip_prefix("0O")) {
         // Octal
         !stripped.is_empty() && stripped.chars().all(|c| matches!(c, '0'..='7'))
-    } else if let Some(stripped) = cleaned
-        .strip_prefix("0b")
-        .or_else(|| cleaned.strip_prefix("0B"))
-    {
+    } else if let Some(stripped) = rest.strip_prefix("0b").or_else(|| rest.strip_prefix("0B")) {
         // Binary
         !stripped.is_empty() && stripped.chars().all(|c| matches!(c, '0' | '1'))
     } else {

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -14,13 +14,22 @@ fn is_numeric_looking(s: &str) -> bool {
         return false;
     }
     let cleaned = s.replace('_', "");
-    if let Some(stripped) = cleaned.strip_prefix("0x").or_else(|| cleaned.strip_prefix("0X")) {
+    if let Some(stripped) = cleaned
+        .strip_prefix("0x")
+        .or_else(|| cleaned.strip_prefix("0X"))
+    {
         // Hex
         !stripped.is_empty() && stripped.chars().all(|c| c.is_ascii_hexdigit())
-    } else if let Some(stripped) = cleaned.strip_prefix("0o").or_else(|| cleaned.strip_prefix("0O")) {
+    } else if let Some(stripped) = cleaned
+        .strip_prefix("0o")
+        .or_else(|| cleaned.strip_prefix("0O"))
+    {
         // Octal
         !stripped.is_empty() && stripped.chars().all(|c| matches!(c, '0'..='7'))
-    } else if let Some(stripped) = cleaned.strip_prefix("0b").or_else(|| cleaned.strip_prefix("0B")) {
+    } else if let Some(stripped) = cleaned
+        .strip_prefix("0b")
+        .or_else(|| cleaned.strip_prefix("0B"))
+    {
         // Binary
         !stripped.is_empty() && stripped.chars().all(|c| matches!(c, '0' | '1'))
     } else {


### PR DESCRIPTION
Remove regex crate as normal runtime dependency.
The regex crate dramatically bloats downstream crates.
Regex was only used in one function. 

Yes, the change is AI generated, but I reviewed it for equivalence with the previous regex code.
I might have missed something, but to me it looks good.
Tests are still passing, regex is moved to dev-depencency.