### PR TITLE
Work on solving #106

### DIFF
--- a/src/anchors.rs
+++ b/src/anchors.rs
@@ -32,6 +32,13 @@
 //! [`.borrow()`](RcRecursive::borrow) or [`.lock()`](ArcRecursive::lock) to access the underlying data.
 //!
 //! For a complete working example of recursive anchors, see `examples/recursive_yaml.rs`.
+//!
+//! ## Limitation: `#[serde(flatten)]` buffering and strong-anchor identity
+//!
+//! Serde may buffer flattened content through internal content deserializers that do not
+//! preserve format-local anchor metadata. In those paths, `RcAnchor` / `ArcAnchor` value
+//! deserialization still succeeds, but full strong-pointer identity may be lost for nested
+//! anchors inside flattened payloads.
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
@@ -688,7 +695,7 @@ where
             where
                 D: serde::de::Deserializer<'de>,
             {
-                let anchor_id = anchor_store::current_rc_anchor();
+                let anchor_id = anchor_store::claim_rc_anchor();
                 let existing = match anchor_id {
                     Some(id) => {
                         Some((id, anchor_store::get_rc::<T>(id).map_err(D::Error::custom)?))
@@ -746,7 +753,7 @@ where
             where
                 D: serde::de::Deserializer<'de>,
             {
-                let anchor_id = anchor_store::current_arc_anchor();
+                let anchor_id = anchor_store::claim_arc_anchor();
                 let existing = match anchor_id {
                     Some(id) => Some((
                         id,
@@ -805,7 +812,7 @@ where
             where
                 D: serde::de::Deserializer<'de>,
             {
-                let anchor_id = anchor_store::current_rc_recursive_anchor();
+                let anchor_id = anchor_store::claim_rc_recursive_anchor();
                 let existing = match anchor_id {
                     Some(id) => Some((
                         id,
@@ -872,7 +879,7 @@ where
             where
                 D: serde::de::Deserializer<'de>,
             {
-                let anchor_id = anchor_store::current_arc_recursive_anchor();
+                let anchor_id = anchor_store::claim_arc_recursive_anchor();
                 let existing = match anchor_id {
                     Some(id) => Some((
                         id,

--- a/src/de/anchor_store.rs
+++ b/src/de/anchor_store.rs
@@ -320,3 +320,269 @@ pub(crate) fn with_document_scope<R>(f: impl FnOnce() -> R) -> R {
     drop(guard);
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::Mutex;
+
+    struct IsolatedState;
+
+    impl Drop for IsolatedState {
+        fn drop(&mut self) {
+            reset();
+        }
+    }
+
+    fn isolated_state() -> IsolatedState {
+        reset();
+        IsolatedState
+    }
+
+    #[test]
+    fn context_without_anchor_does_not_touch_state() {
+        let _state = isolated_state();
+
+        let value = with_anchor_context(AnchorKind::Rc, None, || {
+            assert_eq!(current_rc_anchor(), None);
+            assert!(!rc_anchor_reentrant(1));
+            42
+        });
+
+        assert_eq!(value, 42);
+        assert_eq!(current_rc_anchor(), None);
+        assert!(!rc_anchor_reentrant(1));
+    }
+
+    #[test]
+    fn current_anchor_is_only_innermost_unclaimed_matching_frame() {
+        let _state = isolated_state();
+
+        with_anchor_context(AnchorKind::Rc, Some(7), || {
+            assert_eq!(current_rc_anchor(), Some(7));
+            assert_eq!(current_arc_anchor(), None);
+
+            with_anchor_context(AnchorKind::Arc, Some(8), || {
+                assert_eq!(current_rc_anchor(), None);
+                assert_eq!(current_arc_anchor(), Some(8));
+                assert_eq!(claim_arc_anchor(), Some(8));
+                assert_eq!(current_arc_anchor(), None);
+                assert_eq!(claim_arc_anchor(), None);
+            });
+
+            assert_eq!(current_rc_anchor(), Some(7));
+            assert_eq!(claim_rc_anchor(), Some(7));
+            assert_eq!(current_rc_anchor(), None);
+
+            with_anchor_context(AnchorKind::Rc, Some(9), || {
+                assert_eq!(current_rc_anchor(), Some(9));
+            });
+
+            assert_eq!(claim_rc_anchor(), None);
+        });
+
+        assert_eq!(current_rc_anchor(), None);
+    }
+
+    #[test]
+    fn recursive_current_and_claim_use_distinct_anchor_kinds() {
+        let _state = isolated_state();
+
+        with_anchor_context(AnchorKind::RcRecursive, Some(3), || {
+            assert_eq!(current_rc_recursive_anchor(), Some(3));
+            assert_eq!(current_arc_recursive_anchor(), None);
+            assert!(recursive_anchor_in_progress(3));
+
+            with_anchor_context(AnchorKind::ArcRecursive, Some(3), || {
+                assert_eq!(current_rc_recursive_anchor(), None);
+                assert_eq!(current_arc_recursive_anchor(), Some(3));
+                assert!(recursive_anchor_in_progress(3));
+                assert_eq!(claim_arc_recursive_anchor(), Some(3));
+                assert_eq!(current_arc_recursive_anchor(), None);
+                assert_eq!(claim_arc_recursive_anchor(), None);
+            });
+
+            assert_eq!(current_rc_recursive_anchor(), Some(3));
+            assert_eq!(claim_rc_recursive_anchor(), Some(3));
+            assert_eq!(current_rc_recursive_anchor(), None);
+            assert_eq!(claim_rc_recursive_anchor(), None);
+        });
+
+        assert!(!recursive_anchor_in_progress(3));
+    }
+
+    #[test]
+    fn reentrant_tracking_counts_nested_matching_kind_and_id() {
+        let _state = isolated_state();
+
+        with_anchor_context(AnchorKind::Rc, Some(5), || {
+            assert!(!rc_anchor_reentrant(5));
+
+            with_anchor_context(AnchorKind::Rc, Some(6), || {
+                assert!(!rc_anchor_reentrant(5));
+                assert!(!rc_anchor_reentrant(6));
+            });
+
+            with_anchor_context(AnchorKind::Rc, Some(5), || {
+                assert!(rc_anchor_reentrant(5));
+            });
+
+            assert!(!rc_anchor_reentrant(5));
+        });
+
+        with_anchor_context(AnchorKind::Arc, Some(5), || {
+            with_anchor_context(AnchorKind::Arc, Some(5), || {
+                assert!(arc_anchor_reentrant(5));
+            });
+        });
+
+        with_anchor_context(AnchorKind::RcRecursive, Some(7), || {
+            with_anchor_context(AnchorKind::RcRecursive, Some(7), || {
+                assert!(rc_recursive_reentrant(7));
+            });
+        });
+
+        with_anchor_context(AnchorKind::ArcRecursive, Some(8), || {
+            with_anchor_context(AnchorKind::ArcRecursive, Some(8), || {
+                assert!(arc_recursive_reentrant(8));
+            });
+        });
+
+        assert!(!rc_anchor_reentrant(5));
+        assert!(!arc_anchor_reentrant(5));
+        assert!(!rc_recursive_reentrant(7));
+        assert!(!arc_recursive_reentrant(8));
+    }
+
+    #[test]
+    fn stores_return_matching_values_and_keep_anchor_kinds_separate() {
+        let _state = isolated_state();
+
+        let rc = Rc::new("rc".to_owned());
+        let arc = Arc::new("arc".to_owned());
+        let rc_recursive = Rc::new(RefCell::new(Some(10_i32)));
+        let arc_recursive = Arc::new(Mutex::new(Some(11_i32)));
+
+        store_rc(1, rc.clone());
+        store_arc(1, arc.clone());
+        store_rc_recursive(1, rc_recursive.clone());
+        store_arc_recursive(1, arc_recursive.clone());
+
+        assert!(Rc::ptr_eq(&get_rc::<String>(1).unwrap().unwrap(), &rc));
+        assert!(Arc::ptr_eq(&get_arc::<String>(1).unwrap().unwrap(), &arc));
+        assert!(Rc::ptr_eq(
+            &get_rc_recursive::<RefCell<Option<i32>>>(1)
+                .unwrap()
+                .unwrap(),
+            &rc_recursive
+        ));
+        assert!(Arc::ptr_eq(
+            &get_arc_recursive::<Mutex<Option<i32>>>(1).unwrap().unwrap(),
+            &arc_recursive
+        ));
+
+        assert!(get_rc::<String>(2).unwrap().is_none());
+        assert!(get_arc::<String>(2).unwrap().is_none());
+        assert!(
+            get_rc_recursive::<RefCell<Option<i32>>>(2)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            get_arc_recursive::<Mutex<Option<i32>>>(2)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn stores_report_incompatible_types() {
+        let _state = isolated_state();
+
+        store_rc(1, Rc::new(1_u32));
+        store_arc(2, Arc::new(2_u32));
+        store_rc_recursive(3, Rc::new(RefCell::new(Some(3_u32))));
+        store_arc_recursive(4, Arc::new(Mutex::new(Some(4_u32))));
+
+        assert_eq!(
+            get_rc::<String>(1).unwrap_err(),
+            "anchor id 1 reused with incompatible Rc type"
+        );
+        assert_eq!(
+            get_arc::<String>(2).unwrap_err(),
+            "anchor id 2 reused with incompatible Arc type"
+        );
+        assert_eq!(
+            get_rc_recursive::<RefCell<Option<String>>>(3).unwrap_err(),
+            "recursive anchor id 3 reused with incompatible Rc type"
+        );
+        assert_eq!(
+            get_arc_recursive::<Mutex<Option<String>>>(4).unwrap_err(),
+            "recursive anchor id 4 reused with incompatible Arc type"
+        );
+    }
+
+    #[test]
+    fn reset_clears_contexts_reentrant_counts_and_stores() {
+        let _state = isolated_state();
+
+        with_anchor_context(AnchorKind::Rc, Some(1), || {
+            with_anchor_context(AnchorKind::Rc, Some(1), || {
+                assert!(rc_anchor_reentrant(1));
+            });
+        });
+        store_rc(1, Rc::new("stored".to_owned()));
+
+        assert!(get_rc::<String>(1).unwrap().is_some());
+        reset();
+
+        assert_eq!(current_rc_anchor(), None);
+        assert!(!rc_anchor_reentrant(1));
+        assert!(get_rc::<String>(1).unwrap().is_none());
+    }
+
+    #[test]
+    fn document_scope_resets_before_and_after_success() {
+        let _state = isolated_state();
+
+        store_rc(1, Rc::new(1_i32));
+
+        let result = with_document_scope(|| {
+            assert!(get_rc::<i32>(1).unwrap().is_none());
+
+            store_rc(2, Rc::new(2_i32));
+            with_anchor_context(AnchorKind::Rc, Some(2), || {
+                assert_eq!(current_rc_anchor(), Some(2));
+            });
+
+            "ok"
+        });
+
+        assert_eq!(result, "ok");
+        assert_eq!(current_rc_anchor(), None);
+        assert!(get_rc::<i32>(1).unwrap().is_none());
+        assert!(get_rc::<i32>(2).unwrap().is_none());
+    }
+
+    #[test]
+    fn document_scope_resets_after_panic() {
+        let _state = isolated_state();
+
+        let panic_result = catch_unwind(AssertUnwindSafe(|| {
+            with_document_scope(|| {
+                store_rc(9, Rc::new(9_i32));
+
+                with_anchor_context(AnchorKind::Rc, Some(9), || {
+                    assert_eq!(current_rc_anchor(), Some(9));
+                    panic!("intentional panic while testing anchor store cleanup");
+                });
+            });
+        }));
+
+        assert!(panic_result.is_err());
+        assert_eq!(current_rc_anchor(), None);
+        assert!(!rc_anchor_reentrant(9));
+        assert!(get_rc::<i32>(9).unwrap().is_none());
+    }
+}

--- a/src/de/anchor_store.rs
+++ b/src/de/anchor_store.rs
@@ -22,9 +22,16 @@ struct AnchorStore {
 
 #[derive(Default)]
 struct AnchorState {
-    stack: Vec<(AnchorKind, usize)>,
+    stack: Vec<AnchorFrame>,
     store: AnchorStore,
     in_progress: HashMap<(AnchorKind, usize), usize>,
+}
+
+#[derive(Clone, Copy)]
+struct AnchorFrame {
+    kind: AnchorKind,
+    id: usize,
+    claimed: bool,
 }
 
 thread_local! {
@@ -51,7 +58,11 @@ pub(crate) fn with_anchor_context<R>(
     if let Some(id) = anchor {
         STATE.with(|state| {
             let mut s = state.borrow_mut();
-            s.stack.push((kind, id));
+            s.stack.push(AnchorFrame {
+                kind,
+                id,
+                claimed: false,
+            });
             *s.in_progress.entry((kind, id)).or_insert(0) += 1;
         });
         let guard = Guard { kind, id };
@@ -72,7 +83,16 @@ impl Drop for Guard {
     fn drop(&mut self) {
         STATE.with(|state| {
             let mut s = state.borrow_mut();
-            s.stack.pop();
+            let popped = s.stack.pop();
+            debug_assert!(
+                matches!(
+                    popped,
+                    Some(AnchorFrame { kind, id, .. })
+                        if kind == self.kind && id == self.id
+                ),
+                "anchor context stack corrupted"
+            );
+
             if let Some(count) = s.in_progress.get_mut(&(self.kind, self.id)) {
                 if *count > 1 {
                     *count -= 1;
@@ -84,14 +104,41 @@ impl Drop for Guard {
     }
 }
 
+/// Return the innermost active anchor id for `kind`, but only if that frame has not
+/// already been claimed by the wrapper whose YAML node introduced it.
+///
+/// This is intentionally stricter than searching the whole stack. Searching outward
+/// lets nested `RcAnchor` / `ArcAnchor` values accidentally inherit an enclosing
+/// anchor, which is what caused issue #106.
 fn current_anchor_id(kind: AnchorKind) -> Option<usize> {
     STATE.with(|state| {
-        state
-            .borrow()
-            .stack
-            .iter()
-            .rev()
-            .find_map(|(k, id)| if *k == kind { Some(*id) } else { None })
+        let s = state.borrow();
+        let frame = s.stack.last()?;
+
+        if frame.kind == kind && !frame.claimed {
+            Some(frame.id)
+        } else {
+            None
+        }
+    })
+}
+
+/// Claim the innermost active anchor id for `kind`.
+///
+/// Strong anchor wrappers call this so the frame belongs to exactly one wrapper.
+/// Nested deserialization performed while the wrapper's value is being read can no
+/// longer reuse the enclosing anchor id by accident.
+fn claim_anchor_id(kind: AnchorKind) -> Option<usize> {
+    STATE.with(|state| {
+        let mut s = state.borrow_mut();
+        let frame = s.stack.last_mut()?;
+
+        if frame.kind == kind && !frame.claimed {
+            frame.claimed = true;
+            Some(frame.id)
+        } else {
+            None
+        }
     })
 }
 
@@ -109,6 +156,22 @@ pub(crate) fn current_rc_recursive_anchor() -> Option<usize> {
 
 pub(crate) fn current_arc_recursive_anchor() -> Option<usize> {
     current_anchor_id(AnchorKind::ArcRecursive)
+}
+
+pub(crate) fn claim_rc_anchor() -> Option<usize> {
+    claim_anchor_id(AnchorKind::Rc)
+}
+
+pub(crate) fn claim_arc_anchor() -> Option<usize> {
+    claim_anchor_id(AnchorKind::Arc)
+}
+
+pub(crate) fn claim_rc_recursive_anchor() -> Option<usize> {
+    claim_anchor_id(AnchorKind::RcRecursive)
+}
+
+pub(crate) fn claim_arc_recursive_anchor() -> Option<usize> {
+    claim_anchor_id(AnchorKind::ArcRecursive)
 }
 
 fn anchor_reentrant(kind: AnchorKind, id: usize) -> bool {

--- a/src/de/anchor_store.rs
+++ b/src/de/anchor_store.rs
@@ -566,6 +566,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(panic = "unwind"), ignore = "Test requires panic unwinding")]
     fn document_scope_resets_after_panic() {
         let _state = isolated_state();
 

--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -340,6 +340,12 @@ seq:
     }
 
     #[test]
+    // We cannot fix this due to a limitation in Serde's `#[serde(flatten)]`.
+    // Serde buffers flattened fields into a typeless `Content` enum using a private `FlatMapDeserializer`.
+    // During this buffering phase, format-specific deserialization context—such as the currently active
+    // anchor IDs in `serde-saphyr`—is discarded. When `RcAnchor` is later deserialized from the buffered 
+    // `Content`, it fails to see the original anchor context and creates a new allocation instead of 
+    // preserving pointer identity.
     #[ignore = "requires preserving YAML alias metadata through serde flatten buffering"]
     fn rc_anchor_flatten_nested_empty_should_preserve_inner_identity() {
         #[derive(Deserialize, Debug)]

--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -385,9 +385,15 @@ seq:
         "#};
 
         let file: File = from_str(yaml).expect("nested: [] variant should deserialize");
+        assert!(file.nested.is_empty());
+        assert_eq!(file.inners[0].foo, 17);
+        assert_eq!(file.inners[0].bar, 18);
+
         let outer_inner = match &file.outers[0].action {
             OuterAction::Link { inner } => inner,
         };
+        assert_eq!(outer_inner.foo, 17);
+        assert_eq!(outer_inner.bar, 18);
 
         assert!(
             Rc::ptr_eq(&file.inners[0].0, &outer_inner.0),

--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -207,4 +207,191 @@ seq:
 
         Ok(())
     }
+
+    #[test]
+    fn rc_anchor_flatten_repro_issue_106_does_not_reuse_outer_anchor_as_inner() {
+        #[derive(Deserialize, Debug)]
+        struct Inner {
+            foo: i32,
+            bar: i32,
+        }
+
+        type InnerRc = RcAnchor<Inner>;
+
+        #[derive(Deserialize, Debug)]
+        struct Outer {
+            name: String,
+            #[serde(flatten)]
+            action: OuterAction,
+        }
+
+        #[derive(Deserialize, Debug)]
+        enum OuterAction {
+            #[serde(rename = "link")]
+            Link { inner: InnerRc },
+        }
+
+        type OuterRc = RcAnchor<Outer>;
+
+        #[derive(Deserialize, Debug)]
+        struct Nested {
+            name: String,
+            xyz: OuterRc,
+        }
+
+        #[derive(Deserialize, Debug)]
+        struct File {
+            inners: Vec<InnerRc>,
+            outers: Vec<OuterRc>,
+            nested: Vec<Nested>,
+        }
+
+        let yaml = indoc! {r#"
+            inners:
+            - &one
+              foo: 17
+              bar: 18
+
+            outers:
+            - &two
+              name: one
+              link: { inner: *one }
+
+            nested:
+            - name: wtf
+              xyz: *two
+        "#};
+
+        let file: File = from_str(yaml).expect("issue #106 repro should deserialize");
+
+        assert!(
+            Rc::ptr_eq(&file.outers[0].0, &file.nested[0].xyz.0),
+            "outer alias *two should preserve RcAnchor<Outer> identity"
+        );
+        assert_eq!(file.outers[0].name, "one");
+        assert_eq!(file.nested[0].name, "wtf");
+        assert_eq!(file.inners[0].foo, 17);
+        assert_eq!(file.inners[0].bar, 18);
+
+        let outer_inner = match &file.outers[0].action {
+            OuterAction::Link { inner } => inner,
+        };
+
+        assert_eq!(outer_inner.foo, 17);
+        assert_eq!(outer_inner.bar, 18);
+    }
+
+    #[test]
+    fn rc_anchor_flatten_nested_empty_deserializes_without_outer_context_leak() {
+        #[derive(Deserialize, Debug)]
+        struct Inner {
+            foo: i32,
+            bar: i32,
+        }
+
+        type InnerRc = RcAnchor<Inner>;
+
+        #[derive(Deserialize, Debug)]
+        struct Outer {
+            #[serde(flatten)]
+            action: OuterAction,
+        }
+
+        #[derive(Deserialize, Debug)]
+        enum OuterAction {
+            #[serde(rename = "link")]
+            Link { inner: InnerRc },
+        }
+
+        type OuterRc = RcAnchor<Outer>;
+
+        #[derive(Deserialize, Debug)]
+        struct File {
+            inners: Vec<InnerRc>,
+            outers: Vec<OuterRc>,
+            nested: Vec<()>,
+        }
+
+        let yaml = indoc! {r#"
+            inners:
+            - &one
+              foo: 17
+              bar: 18
+
+            outers:
+            - &two
+              link: { inner: *one }
+
+            nested: []
+        "#};
+
+        let file: File = from_str(yaml).expect("nested: [] variant should deserialize");
+
+        assert!(file.nested.is_empty());
+        assert_eq!(file.inners[0].foo, 17);
+        assert_eq!(file.inners[0].bar, 18);
+
+        let outer_inner = match &file.outers[0].action {
+            OuterAction::Link { inner } => inner,
+        };
+
+        assert_eq!(outer_inner.foo, 17);
+        assert_eq!(outer_inner.bar, 18);
+    }
+
+    #[test]
+    #[ignore = "requires preserving YAML alias metadata through serde flatten buffering"]
+    fn rc_anchor_flatten_nested_empty_should_preserve_inner_identity() {
+        #[derive(Deserialize, Debug)]
+        struct Inner {
+            foo: i32,
+            bar: i32,
+        }
+
+        type InnerRc = RcAnchor<Inner>;
+
+        #[derive(Deserialize, Debug)]
+        struct Outer {
+            #[serde(flatten)]
+            action: OuterAction,
+        }
+
+        #[derive(Deserialize, Debug)]
+        enum OuterAction {
+            #[serde(rename = "link")]
+            Link { inner: InnerRc },
+        }
+
+        type OuterRc = RcAnchor<Outer>;
+
+        #[derive(Deserialize, Debug)]
+        struct File {
+            inners: Vec<InnerRc>,
+            outers: Vec<OuterRc>,
+            nested: Vec<()>,
+        }
+
+        let yaml = indoc! {r#"
+            inners:
+            - &one
+              foo: 17
+              bar: 18
+
+            outers:
+            - &two
+              link: { inner: *one }
+
+            nested: []
+        "#};
+
+        let file: File = from_str(yaml).expect("nested: [] variant should deserialize");
+        let outer_inner = match &file.outers[0].action {
+            OuterAction::Link { inner } => inner,
+        };
+
+        assert!(
+            Rc::ptr_eq(&file.inners[0].0, &outer_inner.0),
+            "inner alias *one inside flattened enum should preserve RcAnchor<Inner> identity"
+        );
+    }
 }


### PR DESCRIPTION
Fixes the incorrect outer-anchor context reuse from #106.

This makes the repro deserialize successfully and preserves the outer *two identity.
Nested strong-anchor identity through #[serde(flatten)] remains a documented limitation.