### PR TITLE
fix: legacy octal handling

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -158,7 +158,7 @@ pub(crate) struct Cfg {
     pub(crate) dup_policy: DuplicateKeyPolicy,
     /// Policy for YAML merge keys (`<<`).
     pub(crate) merge_keys: MergeKeyPolicy,
-    /// If true, accept legacy octal numbers that start with `00`.
+    /// If true, accept legacy octal numbers that start with `0`.
     pub(crate) legacy_octal_numbers: bool,
     /// If true, only accept exact literals `true`/`false` as booleans.
     pub(crate) strict_booleans: bool,

--- a/src/de/options.rs
+++ b/src/de/options.rs
@@ -165,7 +165,7 @@ pub struct Options {
         note = "Direct construction of `Options` will be disabled from 1.0.0, use macro `options!`"
     )]
     pub alias_limits: AliasLimits,
-    /// Enable legacy octal parsing where values starting with `00` are treated as base-8.
+    /// Enable legacy octal parsing where values starting with `0` are treated as base-8.
     /// They are deprecated in YAML 1.2. Default: false.
     #[deprecated(
         note = "Direct construction of `Options` will be disabled from 1.0.0, use macro `options!`"

--- a/src/de/parse_scalars.rs
+++ b/src/de/parse_scalars.rs
@@ -186,6 +186,10 @@ where
 
     let (radix, digits) = radix_and_digits(legacy_octal, rest);
     if radix == 10 {
+        // Yaml 1.2 forbids decimal integer literals starting with zero.
+        if digits.starts_with("0") && digits != "0" {
+            return Err(invalid());
+        }
         let val_i128 = parse_decimal_signed_i128(digits, neg).ok_or_else(invalid)?;
         return T::try_from(val_i128).map_err(|_| invalid());
     }
@@ -220,6 +224,10 @@ where
     let (radix, digits) = radix_and_digits(legacy_octal, rest);
 
     if radix == 10 {
+        // Yaml 1.2 forbids decimal integer literals starting with zero.
+        if digits.starts_with("0") && digits != "0" {
+            return Err(invalid());
+        }
         let val_u128 = parse_decimal_unsigned_u128(digits).ok_or_else(invalid)?;
         return T::try_from(val_u128).map_err(|_| invalid());
     }
@@ -237,12 +245,12 @@ fn radix_and_digits(legacy_octal: bool, rest: &str) -> (u32, &str) {
             (8u32, r)
         } else if let Some(r) = rest.strip_prefix("0b").or_else(|| rest.strip_prefix("0B")) {
             (2u32, r)
-        } else if legacy_octal && rest.starts_with("00") {
-            if rest == "00" {
-                // 00 is 0 and not empty string
+        } else if legacy_octal && rest.starts_with("0") {
+            if rest == "0" {
+                // 0 is 0 and not empty string
                 (8u32, "0")
             } else {
-                (8u32, &rest[2..])
+                (8u32, &rest[1..])
             }
         } else {
             (10u32, rest)

--- a/tests/de_coverage.rs
+++ b/tests/de_coverage.rs
@@ -738,8 +738,8 @@ fn merge_key_invalid_scalar_error() {
 #[test]
 fn deserialize_any_legacy_octal() {
     let opts = serde_saphyr::options! { legacy_octal_numbers: true };
-    let v: serde_json::Value = serde_saphyr::from_str_with_options("00777\n", opts).unwrap();
-    // 00777 legacy octal = 511 decimal
+    let v: serde_json::Value = serde_saphyr::from_str_with_options("0777\n", opts).unwrap();
+    // 0777 legacy octal = 511 decimal
     assert_eq!(
         v,
         serde_json::Value::Number(serde_json::Number::from(511u64))

--- a/tests/number_bases.rs
+++ b/tests/number_bases.rs
@@ -10,12 +10,10 @@ struct Numbers {
     neg_hex: i64,
     neg_bin: i16,
     u_hex: u32,
-    legacy_u16: u16,
 }
 
 #[test]
 fn parse_numeric_bases_default() {
-    // legacy_octal_numbers is false by default: 0052 is parsed as decimal 52
     let y = r#"
 hex_i32: 0x2A
 oct_i32: 0o52
@@ -23,7 +21,6 @@ bin_i8: 0b1010
 neg_hex: -0x2A
 neg_bin: -0b11
 u_hex: 0xFF
-legacy_u16: 0052
 "#;
     let v: Numbers = serde_saphyr::from_str(y).expect("parse failed");
     assert_eq!(v.hex_i32, 42);
@@ -32,8 +29,6 @@ legacy_u16: 0052
     assert_eq!(v.neg_hex, -42);
     assert_eq!(v.neg_bin, -3);
     assert_eq!(v.u_hex, 255);
-    // legacy disabled: 0052 is decimal fifty-two
-    assert_eq!(v.legacy_u16, 52);
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -42,9 +37,18 @@ struct OnlyLegacy {
 }
 
 #[test]
+fn zero_prefix_is_forbidden() {
+    // legacy_octal_numbers is false by default: 052 is an error
+    let y = r#"
+legacy_u16: 052
+"#;
+    serde_saphyr::from_str::<OnlyLegacy>(y).expect_err("zero-prefixed decimals are forbidden");
+}
+
+#[test]
 fn parse_numeric_bases_with_legacy_octal() {
     let y = r#"
-legacy_u16: 0052
+legacy_u16: 052
 "#;
     let opts = serde_saphyr::options! { legacy_octal_numbers: true };
     let v: OnlyLegacy = serde_saphyr::from_str_with_options(y, opts).expect("parse failed");

--- a/tests/serde_yaml/test_serde.rs
+++ b/tests/serde_yaml/test_serde.rs
@@ -298,14 +298,14 @@ fn test_strings_needing_quote() {
         integer: "1".to_owned(),
         void: "null".to_owned(),
         xnan: "NaN".to_owned(),
-        leading_zeros: "007".to_owned(),
+        leading_zeros: "07".to_owned(),
         ok: "OK".to_owned(), // does not need quote
     };
     let yaml = r#"boolean: "true"
 integer: "1"
 void: "null"
 xnan: "NaN"
-leading_zeros: "007"
+leading_zeros: "07"
 ok: OK
 "#;
     test_serde(&thing, yaml);


### PR DESCRIPTION
This library doesn't seem to handle legacy octals well according to neither yaml 1.2 spec (explicitly rejected), neither to yaml 1.1 spec (prefixed with 0, and not 00)