### PR TITLE
Fix most of the errors emitted by cargo doc

### DIFF
--- a/src/anchors.rs
+++ b/src/anchors.rs
@@ -106,7 +106,7 @@ pub struct RcAnchor<T>(pub Rc<T>);
 #[derive(Clone)]
 pub struct ArcAnchor<T>(pub Arc<T>);
 
-/// A wrapper around [`Weak<T>`] (from [`std::rc`]) that opt-ins for **anchor emission**.
+/// A wrapper around [`std::rc::Weak<T>`] that opt-ins for **anchor emission**.
 ///
 /// When serialized, if the weak reference is **dangling** (i.e., the value was dropped),
 /// it emits `null` to indicate that the target no longer exists.
@@ -135,9 +135,9 @@ pub struct ArcAnchor<T>(pub Arc<T>);
 #[derive(Clone)]
 pub struct RcWeakAnchor<T>(pub RcWeak<T>);
 
-/// A wrapper around [`Weak<T>`] (from [`std::sync`]) that opt-ins for **anchor emission**.
+/// A wrapper around [`std::sync::Weak<T>`] that opt-ins for **anchor emission**.
 ///
-/// This variant is thread-safe and uses [`Arc`] / [`Weak`] instead of [`Rc`].
+/// This variant is thread-safe and uses [`Arc`] / [`Weak`](std::sync::Weak) instead of [`Rc`].
 /// If the weak reference is **dangling**, it serializes as `null`.
 ///
 /// > **Deserialization note:** `null` → dangling weak. Non-`null` is rejected unless a registry is used.

--- a/src/de/budget.rs
+++ b/src/de/budget.rs
@@ -258,7 +258,7 @@ pub enum BudgetBreach {
     /// opening event (depth underflow). Indicates malformed or truncated input.
     SequenceUnbalanced,
 
-    /// The total number of input bytes exceeded [`Budget::max_input_bytes`].
+    /// The total number of input bytes exceeded [`Budget::max_reader_input_bytes`].
     InputBytes {
         /// Total number of bytes consumed from the input when the breach occurred.
         input_bytes: usize,

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -773,7 +773,7 @@ pub enum Error {
         location: Location,
     },
 
-    /// Indentation does not meet the configured [`RequireIndent`] requirement.
+    /// Indentation does not meet the configured [`RequireIndent`](crate::RequireIndent) requirement.
     IndentationError {
         /// The indentation requirement that was violated.
         required: crate::indentation::RequireIndent,

--- a/src/de/indentation.rs
+++ b/src/de/indentation.rs
@@ -1,6 +1,6 @@
 /// Requirements for indentation validation during YAML deserialization.
 ///
-/// When set via [`options!`](crate::options), the deserializer validates every
+/// When set via [`options!`](crate::options!), the deserializer validates every
 /// parser-reported indentation level against the chosen policy.
 ///
 /// # Variants

--- a/src/de/localizer.rs
+++ b/src/de/localizer.rs
@@ -102,7 +102,7 @@ pub trait Localizer {
 
     /// Label used when a path has no leaf.
     ///
-    /// Default <root>
+    /// Default `<root>`
     fn root_path_label(&self) -> Cow<'static, str> {
         Cow::Borrowed("<root>")
     }

--- a/src/de/options.rs
+++ b/src/de/options.rs
@@ -188,7 +188,7 @@ pub struct Options {
     pub ignore_binary_tag_for_string: bool,
     /// Activates YAML conventions common in robotics community. These extensions support
     /// conversion functions (deg, rad) and simple mathematical expressions such as deg(180),
-    /// rad(pi), 1 + 2*(3 - 4/5), or rad(pi/2). [robotics] feature must also be enabled.
+    /// rad(pi), 1 + 2*(3 - 4/5), or rad(pi/2). `robotics` feature must also be enabled.
     #[deprecated(
         note = "Direct construction of `Options` will be disabled from 1.0.0, use macro `options!`"
     )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ pub fn to_writer<W: std::fmt::Write, T: serde::Serialize>(
     value.serialize(&mut ser)
 }
 
-/// Serialize a value as YAML into any [`fmt::Write`] target.
+/// Serialize a value as YAML into any [`std::fmt::Write`] target.
 #[cfg(feature = "serialize")]
 pub fn to_fmt_writer<W: std::fmt::Write, T: serde::Serialize>(
     output: &mut W,
@@ -210,7 +210,7 @@ pub fn to_fmt_writer<W: std::fmt::Write, T: serde::Serialize>(
     to_fmt_writer_with_options(output, value, SerializerOptions::default())
 }
 
-/// Serialize a value as YAML into any [`io::Write`] target.
+/// Serialize a value as YAML into any [`std::io::Write`] target.
 #[cfg(feature = "serialize")]
 pub fn to_io_writer<W: std::io::Write, T: serde::Serialize>(
     output: &mut W,
@@ -219,7 +219,7 @@ pub fn to_io_writer<W: std::io::Write, T: serde::Serialize>(
     to_io_writer_with_options(output, value, SerializerOptions::default())
 }
 
-/// Serialize a value as YAML into any [`fmt::Write`] target, with options.
+/// Serialize a value as YAML into any [`std::fmt::Write`] target, with options.
 /// Options are consumed because anchor generator may be taken from them.
 #[cfg(feature = "serialize")]
 pub fn to_fmt_writer_with_options<W: std::fmt::Write, T: serde::Serialize>(
@@ -232,7 +232,7 @@ pub fn to_fmt_writer_with_options<W: std::fmt::Write, T: serde::Serialize>(
     value.serialize(&mut ser)
 }
 
-/// Serialize a value as YAML into any [`io::Write`] target, with options.
+/// Serialize a value as YAML into any [`std::io::Write`] target, with options.
 /// Options are consumed because anchor generator may be taken from them.
 #[cfg(feature = "serialize")]
 pub fn to_io_writer_with_options<W: std::io::Write, T: serde::Serialize>(

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -5,6 +5,7 @@
 //!
 //! Usage example:
 //!
+//! ```
 //! use serde::Serialize;
 //! use std::rc::Rc;
 //! use serde_saphyr::{to_string, RcAnchor, LitStr, FlowSeq};
@@ -29,6 +30,7 @@
 //!     };
 //!     println!("{}", to_string(&cfg).unwrap());
 //! }
+//! ```
 
 pub mod error;
 pub mod options;
@@ -271,7 +273,7 @@ type AnchorId = u32;
 /// This type implements `serde::Serializer` and writes YAML to a `fmt::Write`.
 /// It manages indentation, flow/block styles, and YAML anchors/aliases.
 ///
-/// This type is also re-exported from the crate root as [`serde_saphyr::Serializer`].
+/// This type is also re-exported from the crate root as [`serde_saphyr::Serializer`](crate::Serializer).
 ///
 /// ## Example
 ///

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -89,7 +89,6 @@ pub struct SpaceAfter<T>(pub T);
 /// ignored for complex inner values. Value with `Commented` wrapper will be
 /// deserialized correctly as well, but deserializing comments is currently not
 /// supported.
-/// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Commented<T>(pub T, pub String);
 


### PR DESCRIPTION
Fixes:

- Broken links
- Broken markup
- A renamed item

I wasn't sure what to do about this one, so it remains:

```text
$ cargo doc
warning: public documentation for `is_valid` links to private item `crate::de_error::Error::with_location`
   --> src/de/indentation.rs:116:61
    |
116 |     /// correct location later via [`Error::with_location`](crate::de_error::Error::with_location).
    |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this item is private
    |
    = note: this link will resolve properly if you pass `--document-private-items`
    = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
```
