### PR TITLE
Fix #115 : correct block-scalar auto-selection and indentation indicator

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -63,7 +63,10 @@ use nohash_hasher::BuildNoHashHasher;
 // ------------------------------------------------------------
 
 pub use self::error::Error;
-use self::quoting::{is_block_scalar_content_safe, is_plain_safe, is_plain_value_safe};
+use self::quoting::{
+    is_auto_block_scalar_readable, is_block_scalar_content_safe, is_plain_safe,
+    is_plain_value_safe,
+};
 
 /// Result alias.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -907,33 +910,21 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
         // If no explicit style pending, auto-select block style.
         //
         // Controlled by `prefer_block_scalars`:
-        //  - multiline + long (by folded_wrap_col) → literal (|)
-        //  - otherwise, multiline → literal (|) only when newlines are the only reason plain
-        //    style is unsafe
+        //  - multiline → literal (|) whenever the content is representable in a block scalar
+        //    and is readable enough to auto-select (see `is_auto_block_scalar_readable`).
+        //    Block scalars happily contain ':', '#', YAML-like text, etc. — those are unsafe
+        //    in plain style but fine as block content.
         //  - single-line + long (by folded_wrap_col) → folded (>)
         //
         // Also skip block scalars when quote_all is enabled - use quoted strings instead.
         if self.pending_str_style.is_none() && self.in_flow == 0 && !self.quote_all {
-            use self::quoting::is_plain_value_safe;
-
             if v.contains('\n') {
-                if self.prefer_block_scalars {
-                    // If it's already multiline and long, emit literal block style for readability.
-                    let char_len = v.chars().count();
-                    if char_len > self.folded_wrap_col {
-                        self.pending_str_style = Some(StrStyle::Literal);
-                        self.pending_str_from_auto = true;
-                    } else {
-                        // If removing newlines makes it plain-safe, then the only problem was
-                        // newlines → allow literal block style. Otherwise, don't auto-select block
-                        // style so that quoting logic handles it (e.g., values ending with ':').
-                        let trimmed = v.trim_end_matches('\n');
-                        let normalized = trimmed.replace('\n', " ");
-                        if is_plain_value_safe(&normalized, self.yaml_12, false) {
-                            self.pending_str_style = Some(StrStyle::Literal);
-                            self.pending_str_from_auto = true;
-                        }
-                    }
+                if self.prefer_block_scalars
+                    && is_block_scalar_content_safe(v)
+                    && is_auto_block_scalar_readable(v)
+                {
+                    self.pending_str_style = Some(StrStyle::Literal);
+                    self.pending_str_from_auto = true;
                 }
             } else if self.prefer_block_scalars {
                 // Single-line string. If it needs quoting as a value, don't auto-fold.
@@ -987,11 +978,16 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
                 self.write_indent(base)?;
             }
             // Compute the indentation indicator N for block scalars.
-            // N = indent_step * body_base = number of spaces the parser will strip.
-            // We must emit an explicit indicator when the first non-empty content line
-            // has leading whitespace, so the parser knows how much to strip.
+            //
+            // Per YAML 1.2 8.1.1.1, the indicator is the *additional* indentation steps
+            // beyond the parent node's indentation level — NOT the absolute column count.
+            // Since our body is exactly one serializer depth (i.e. `indent_step` spaces)
+            // deeper than its parent, the indicator is simply `indent_step`.
+            //
+            // We only emit it when the first non-empty content line has leading whitespace,
+            // which would otherwise prevent automatic indentation detection by the parser.
             let body_base = base + 1;
-            let indent_n = self.indent_step * body_base;
+            let indent_n = self.indent_step;
 
             // Check if we need an explicit indentation indicator.
             // Required when the first non-empty line has leading whitespace.

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1019,15 +1019,23 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
             let first_line_spaces = self::wrapping::first_line_leading_spaces(content_trimmed);
             let needs_indicator = first_line_spaces > 0;
 
-            // The indicator must be in 1..=9. Fall back to quoting otherwise.
+            // Resolve the indicator digit up front. If the helper rejects `indent_n`
+            // (i.e. outside the YAML 1.2 `[1-9]` grammar), fall back to quoting.
             // Anchor prefix is already written above, so don't call it again here.
-            if needs_indicator && !(1..=9).contains(&indent_n) {
-                self.pending_str_style = None;
-                self.pending_str_from_auto = false;
-                self.write_plain_or_quoted_value(v)?;
-                self.write_end_of_scalar()?;
-                return Ok(());
-            }
+            let indicator_digit = if needs_indicator {
+                match block_indent_indicator_digit(indent_n) {
+                    Ok(d) => Some(d),
+                    Err(_) => {
+                        self.pending_str_style = None;
+                        self.pending_str_from_auto = false;
+                        self.write_plain_or_quoted_value(v)?;
+                        self.write_end_of_scalar()?;
+                        return Ok(());
+                    }
+                }
+            } else {
+                None
+            };
 
             match style {
                 StrStyle::Literal => {
@@ -1040,9 +1048,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
 
                     // Write block scalar header: | or |N with optional chomp indicator
                     self.out.write_char('|')?;
-                    if needs_indicator {
-                        // Write the indentation indicator digit
-                        let digit = block_indent_indicator_digit(indent_n)?;
+                    if let Some(digit) = indicator_digit {
                         self.out.write_char(digit)?;
                     }
                     match trailing_nl {
@@ -1094,9 +1100,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
                 StrStyle::Folded => {
                     // Write block scalar header: > or >N with optional chomp indicator
                     self.out.write_char('>')?;
-                    if needs_indicator {
-                        // Write the indentation indicator digit
-                        let digit = block_indent_indicator_digit(indent_n)?;
+                    if let Some(digit) = indicator_digit {
                         self.out.write_char(digit)?;
                     }
                     if self.pending_str_from_auto {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -914,7 +914,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
     fn serialize_str(self, v: &str) -> Result<()> {
         #[inline]
         fn block_indent_indicator_digit(indent_n: usize) -> Result<char> {
-            // YAML 1.2 §8.1.1.1: the block-scalar indentation indicator is `[1-9]`.
+            // YAML 1.2 8.1.1.1: the block-scalar indentation indicator is `[1-9]`.
             // `char::from_digit` would accept 0, so we gate on the range explicitly.
             match indent_n {
                 1..=9 => Ok(char::from_digit(indent_n as u32, 10).expect("checked 1..=9")),

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -902,9 +902,14 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
     fn serialize_str(self, v: &str) -> Result<()> {
         #[inline]
         fn block_indent_indicator_digit(indent_n: usize) -> Result<char> {
-            char::from_digit(indent_n as u32, 10).ok_or_else(|| {
-                Error::custom("indentation indicator must be a single digit (1..=9)")
-            })
+            // YAML 1.2 §8.1.1.1: the block-scalar indentation indicator is `[1-9]`.
+            // `char::from_digit` would accept 0, so we gate on the range explicitly.
+            match indent_n {
+                1..=9 => Ok(char::from_digit(indent_n as u32, 10).expect("checked 1..=9")),
+                _ => Err(Error::custom(
+                    "indentation indicator must be a single digit (1..=9)",
+                )),
+            }
         }
 
         // If no explicit style pending, auto-select block style.
@@ -977,6 +982,12 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
             if self.at_line_start {
                 self.write_indent(base)?;
             }
+
+            // Anchors/tags are node properties and must be emitted before scalar content.
+            // For a block scalar this produces e.g. `text: &a1 |` — without this, a pending
+            // anchor would leak onto the next scalar.
+            self.write_scalar_prefix_if_anchor()?;
+
             // Compute the indentation indicator N for block scalars.
             //
             // Per YAML 1.2 8.1.1.1, the indicator is the *additional* indentation steps
@@ -995,12 +1006,11 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
             let first_line_spaces = self::wrapping::first_line_leading_spaces(content_trimmed);
             let needs_indicator = first_line_spaces > 0;
 
-            // If N > 9, YAML parsers reject it. Fall back to quoting.
-            if needs_indicator && indent_n > 9 {
-                // Reset state and fall through to quoted string handling
+            // The indicator must be in 1..=9. Fall back to quoting otherwise.
+            // Anchor prefix is already written above, so don't call it again here.
+            if needs_indicator && !(1..=9).contains(&indent_n) {
                 self.pending_str_style = None;
                 self.pending_str_from_auto = false;
-                self.write_scalar_prefix_if_anchor()?;
                 self.write_plain_or_quoted_value(v)?;
                 self.write_end_of_scalar()?;
                 return Ok(());

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -64,8 +64,7 @@ use nohash_hasher::BuildNoHashHasher;
 
 pub use self::error::Error;
 use self::quoting::{
-    is_auto_block_scalar_readable, is_block_scalar_content_safe, is_plain_safe,
-    is_plain_value_safe,
+    is_auto_block_scalar_readable, is_block_scalar_content_safe, is_plain_safe, is_plain_value_safe,
 };
 
 /// Result alias.

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -463,15 +463,28 @@ impl<'a, W: Write> YamlSerializer<'a, W> {
         Ok(())
     }
 
+    /// Append a pending inline comment, if any.
+    ///
+    /// Used both by normal scalar emission (`value # comment\n`) and by
+    /// block-scalar headers (`| # comment\n`). Comments are suppressed in flow
+    /// style, matching the existing serializer policy.
+    #[inline]
+    fn write_pending_inline_comment(&mut self) -> Result<()> {
+        if self.in_flow == 0
+            && let Some(c) = self.pending_inline_comment.take()
+        {
+            self.out.write_str(" # ")?;
+            self.out.write_str(&c)?;
+        }
+        Ok(())
+    }
+
     /// Called at the end of emitting a scalar in block style: appends a pending inline
     /// comment (if any) and then emits a newline. In flow style, comments are suppressed.
     #[inline]
     fn write_end_of_scalar(&mut self) -> Result<()> {
         if self.in_flow == 0 {
-            if let Some(c) = self.pending_inline_comment.take() {
-                self.out.write_str(" # ")?;
-                self.out.write_str(&c)?;
-            }
+            self.write_pending_inline_comment()?;
             self.newline()?;
         }
         Ok(())
@@ -1037,6 +1050,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
                         1 => {} // clip is the default, no indicator needed
                         _ => self.out.write_char('+')?,
                     }
+                    self.write_pending_inline_comment()?;
                     self.newline()?;
 
                     // Emit body lines. For non-empty content, write each line exactly once.
@@ -1098,6 +1112,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
                     }
                     // Note: Explicit FoldStr/FoldString wrappers historically used plain '>'
                     // regardless of trailing newline; keep that behavior for compatibility.
+                    self.write_pending_inline_comment()?;
                     self.newline()?;
                     self.write_folded_block(v, body_base)?;
                 }

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -333,9 +333,15 @@ pub(crate) fn is_plain_value_safe(s: &str, yaml_12: bool, in_flow: bool) -> bool
 /// relying on double-quoted escape sequences.
 ///
 /// This is character-level safety only: it says whether the codepoints can be
-/// represented inside `|`/`>` blocks. YAML parsers normalize line breaks, so
-/// `\r`/NEL/LS/PS would corrupt the round-trip. BOM is excluded from `nb-char`
-/// in the YAML 1.2 grammar.
+/// represented inside `|`/`>` blocks.
+///
+/// - `\r` is a YAML 1.2 line break (parsers normalize it to `\n`) and must be
+///   escaped to preserve the exact Rust string on round-trip.
+/// - BOM (U+FEFF) is excluded from the `nb-char` production and must be escaped.
+/// - NEL, LS, and PS are non-break characters in YAML 1.2, but many tools and
+///   editors mishandle them; we reject them in block scalars as a conservative
+///   interoperability/readability policy. The double-quoted path preserves them
+///   exactly via `\N`/`\L`/`\P` escapes.
 #[inline]
 pub(crate) fn is_block_scalar_content_safe(s: &str) -> bool {
     s.chars().all(|ch| match ch {

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -331,22 +331,49 @@ pub(crate) fn is_plain_value_safe(s: &str, yaml_12: bool, in_flow: bool) -> bool
 
 /// Returns true when `s` can be emitted literally inside a block scalar without
 /// relying on double-quoted escape sequences.
+///
+/// This is character-level safety only: it says whether the codepoints can be
+/// represented inside `|`/`>` blocks. YAML parsers normalize line breaks, so
+/// `\r`/NEL/LS/PS would corrupt the round-trip. BOM is excluded from `nb-char`
+/// in the YAML 1.2 grammar.
 #[inline]
 pub(crate) fn is_block_scalar_content_safe(s: &str) -> bool {
-    s.chars().all(|ch| {
-        if matches!(ch, '\n' | '\t') {
-            return true;
-        }
-
-        if matches!(ch, '\r' | '\u{0085}' | '\u{2028}' | '\u{2029}') {
-            return false;
-        }
-
-        matches!(
-            ch as u32,
+    s.chars().all(|ch| match ch {
+        '\n' | '\t' => true,
+        '\r' | '\u{0085}' | '\u{2028}' | '\u{2029}' | '\u{FEFF}' => false,
+        c => matches!(
+            c as u32,
             0x20..=0x7E | 0xA0..=0xD7FF | 0xE000..=0xFFFD | 0x10000..=0x10FFFF
-        )
+        ),
     })
+}
+
+/// Readability policy for auto-selected block scalars.
+///
+/// Distinct from [`is_block_scalar_content_safe`]: that asks "can this be a
+/// block scalar at all?", whereas this asks "should we pick block style for
+/// this content automatically?". Explicit `LitStr`/`LitString` wrappers bypass
+/// this gate — the user opted in.
+///
+/// Currently rejects:
+/// - empty strings (nothing to put in a block body);
+/// - lines with trailing space/tab before a newline (editors, formatters, and
+///   copy-paste routinely strip these, so the double-quoted path is safer).
+#[inline]
+pub(crate) fn is_auto_block_scalar_readable(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let bytes = s.as_bytes();
+    for i in 1..bytes.len() {
+        if bytes[i] == b'\n' {
+            let prev = bytes[i - 1];
+            if prev == b' ' || prev == b'\t' {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 fn contains_any_or_is_control(string: &str, values: &[char]) -> bool {

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -358,28 +358,15 @@ pub(crate) fn is_block_scalar_content_safe(s: &str) -> bool {
 ///
 /// Distinct from [`is_block_scalar_content_safe`]: that asks "can this be a
 /// block scalar at all?", whereas this asks "should we pick block style for
-/// this content automatically?". Explicit `LitStr`/`LitString` wrappers bypass
-/// this gate — the user opted in.
+/// this content automatically?".
 ///
-/// Currently rejects:
-/// - empty strings (nothing to put in a block body);
-/// - lines with trailing space/tab before a newline (editors, formatters, and
-///   copy-paste routinely strip these, so the double-quoted path is safer).
+/// Intentionally permissive. Trailing spaces/tabs are preserved by YAML block
+/// scalars and are a tooling/presentation concern, not a scalar safety concern.
+/// A future option can opt into a stricter policy for users who prefer quoted
+/// output when line-end whitespace is present.
 #[inline]
 pub(crate) fn is_auto_block_scalar_readable(s: &str) -> bool {
-    if s.is_empty() {
-        return false;
-    }
-    let bytes = s.as_bytes();
-    for i in 1..bytes.len() {
-        if bytes[i] == b'\n' {
-            let prev = bytes[i - 1];
-            if prev == b' ' || prev == b'\t' {
-                return false;
-            }
-        }
-    }
-    true
+    !s.is_empty()
 }
 
 fn contains_any_or_is_control(string: &str, values: &[char]) -> bool {

--- a/tests/serialize_string_fields_quoted.rs
+++ b/tests/serialize_string_fields_quoted.rs
@@ -38,9 +38,12 @@ fn strings_that_look_special_are_quoted() -> Result<()> {
         out.contains("ending_colon: \"hi:\""),
         "ending colon must be quoted: {out}"
     );
+    // Multiline strings auto-select literal block style when the content is representable
+    // (the trailing `:` is fine as block content). The round-trip below verifies that
+    // the value is still preserved exactly.
     assert!(
-        out.contains("trim_ending_colon: \"hey:\\n\""),
-        "ending colon must be quoted: {out}"
+        out.contains("trim_ending_colon: |\n  hey:\n"),
+        "multiline ending colon should round-trip via literal block: {out}"
     );
 
     let r = serde_saphyr::from_str(&out)?;

--- a/tests/strict_booleans.rs
+++ b/tests/strict_booleans.rs
@@ -66,5 +66,13 @@ fn strict_booleans_with_no_schema_should_not_require_quoting_y_key() {
 "#;
     let got: StrictBoolKey = serde_saphyr::from_str_with_options(yaml, opts)
         .expect("strict_booleans + no_schema should accept bare YAML 1.1 boolean literals as keys");
-    assert_eq!(got, StrictBoolKey { y: 1, yes: 2, on: 3, enabled: 4 });
+    assert_eq!(
+        got,
+        StrictBoolKey {
+            y: 1,
+            yes: 2,
+            on: 3,
+            enabled: 4
+        }
+    );
 }

--- a/tests/test_block_str.rs
+++ b/tests/test_block_str.rs
@@ -385,17 +385,20 @@ fn verdanta_case_fold() -> anyhow::Result<()> {
     let yaml = to_string_with_options(&object, opts)?;
 
     // Block scalar bodies must be indented deeper than the `description: >` header.
+    // The anchor attached to each `RcAnchor<Option<FoldString>>` is correctly placed on
+    // the block scalar node itself (`description: &aN >`) rather than leaking to a
+    // sibling key.
     assert!(
-        yaml.contains("description: >\n  00This is"),
-        "Top-level description body must be indented"
+        yaml.contains("description: &a2 >\n  00This is"),
+        "Top-level description anchor must sit on its block scalar and body must be indented:\n{yaml}"
     );
     assert!(
-        yaml.contains("    description: >\n      01This is"),
-        "Nested description body must be indented deeper than its header"
+        yaml.contains("    description: &a4 >\n      01This is"),
+        "Nested description body must be indented deeper than its header:\n{yaml}"
     );
     assert!(
-        yaml.contains("        description: >\n          02This is"),
-        "Deeply nested description body must be indented deeper than its header"
+        yaml.contains("        description: &a6 >\n          02This is"),
+        "Deeply nested description body must be indented deeper than its header:\n{yaml}"
     );
 
     let opts = serde_saphyr::ser_options! {
@@ -403,16 +406,16 @@ fn verdanta_case_fold() -> anyhow::Result<()> {
     };
     let compact_yaml = to_string_with_options(&object, opts)?;
     assert!(
-        compact_yaml.contains("description: >\n  00This is"),
-        "Top-level description body must be indented"
+        compact_yaml.contains("description: &a2 >\n  00This is"),
+        "Top-level description body must be indented:\n{compact_yaml}"
     );
     assert!(
-        compact_yaml.contains("  description: >\n    01This is"),
-        "Nested description body must be indented deeper than its header"
+        compact_yaml.contains("  description: &a4 >\n    01This is"),
+        "Nested description body must be indented deeper than its header:\n{compact_yaml}"
     );
     assert!(
-        compact_yaml.contains("    description: >\n      02This is"),
-        "Deeply nested description body must be indented deeper than its header"
+        compact_yaml.contains("    description: &a6 >\n      02This is"),
+        "Deeply nested description body must be indented deeper than its header:\n{compact_yaml}"
     );
     let parsed: RcAnchor<Node2> = serde_saphyr::from_str(&compact_yaml)?;
     assert_eq!(parsed.name, object.name);

--- a/tests/test_prefer_block_scalars.rs
+++ b/tests/test_prefer_block_scalars.rs
@@ -241,6 +241,55 @@ fn nested_literal_block_with_leading_space_round_trips() {
 }
 
 #[test]
+fn anchored_auto_literal_block_emits_anchor_before_block_scalar() {
+    use std::collections::BTreeMap;
+    use std::rc::Rc;
+
+    use serde_saphyr::RcAnchor;
+
+    #[derive(Clone, Serialize, Deserialize)]
+    struct Holder {
+        text: RcAnchor<String>,
+        next: String,
+    }
+
+    let shared = Rc::new("def foo():\n    print(42)\n".to_string());
+    let value = vec![
+        Holder {
+            text: RcAnchor::from(shared.clone()),
+            next: "after first".to_string(),
+        },
+        Holder {
+            text: RcAnchor::from(shared),
+            next: "after second".to_string(),
+        },
+    ];
+
+    let yaml = serde_saphyr::to_string(&value).unwrap();
+
+    assert!(
+        yaml.contains("text: &a1 |\n") || yaml.contains("text: &a1 |-\n"),
+        "anchor must be attached to the block scalar itself:\n{yaml}"
+    );
+    assert!(
+        yaml.contains("text: *a1"),
+        "second occurrence should be an alias:\n{yaml}"
+    );
+    assert!(
+        !yaml.contains("next: &a1"),
+        "pending anchor leaked to the next scalar:\n{yaml}"
+    );
+
+    // Re-parse with a generic structure to confirm both shapes round-trip.
+    let parsed: Vec<BTreeMap<String, String>> = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(parsed.len(), 2);
+    assert_eq!(parsed[0]["text"], "def foo():\n    print(42)\n");
+    assert_eq!(parsed[1]["text"], "def foo():\n    print(42)\n");
+    assert_eq!(parsed[0]["next"], "after first");
+    assert_eq!(parsed[1]["next"], "after second");
+}
+
+#[test]
 fn deeply_nested_literal_block_with_leading_space_round_trips() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     struct A {

--- a/tests/test_prefer_block_scalars.rs
+++ b/tests/test_prefer_block_scalars.rs
@@ -179,7 +179,10 @@ fn block_scalar_auto_rejects_bom() {
     use std::collections::BTreeMap;
 
     let mut input = BTreeMap::new();
-    input.insert("text".to_string(), "before\u{FEFF}after\nmore\n".to_string());
+    input.insert(
+        "text".to_string(),
+        "before\u{FEFF}after\nmore\n".to_string(),
+    );
 
     let yaml = serde_saphyr::to_string(&input).unwrap();
 

--- a/tests/test_prefer_block_scalars.rs
+++ b/tests/test_prefer_block_scalars.rs
@@ -290,6 +290,70 @@ fn anchored_auto_literal_block_emits_anchor_before_block_scalar() {
 }
 
 #[test]
+fn commented_auto_folded_block_keeps_inline_comment_on_header() {
+    use std::collections::BTreeMap;
+
+    use serde_saphyr::Commented;
+
+    #[derive(Serialize)]
+    struct Wrap {
+        text: Commented<String>,
+    }
+
+    // Single-line string longer than the default 80-char fold width auto-selects
+    // the folded `>` block style.
+    let input_text = "word ".repeat(20) + "end";
+
+    let value = Wrap {
+        text: Commented(input_text.clone(), "long folded comment".to_string()),
+    };
+
+    let yaml = serde_saphyr::to_string(&value).unwrap();
+
+    assert!(
+        yaml.contains("text: >-") || yaml.contains("text: >"),
+        "expected folded block scalar header: {yaml}"
+    );
+    assert!(
+        yaml.contains("# long folded comment\n"),
+        "inline comment should appear on the folded block header: {yaml}"
+    );
+
+    let back: BTreeMap<String, String> = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(back["text"], input_text);
+}
+
+#[test]
+fn block_scalar_with_invalid_indent_step_falls_back_to_quoted() {
+    // `indent_step` outside 1..=9 cannot be represented as a YAML block-scalar
+    // indentation indicator. When the content needs an explicit indicator
+    // (its first non-empty line has leading whitespace), the serializer must
+    // fall back to the quoted form rather than emit an invalid header.
+    use std::collections::BTreeMap;
+
+    let opts = serde_saphyr::ser_options! {
+        indent_step: 10,
+    };
+
+    let mut input = BTreeMap::new();
+    input.insert("text".to_string(), " leading\nsecond\n".to_string());
+
+    let yaml = serde_saphyr::to_string_with_options(&input, opts).unwrap();
+
+    assert!(
+        !yaml.contains("text: |") && !yaml.contains("text: >"),
+        "must not emit a block scalar with an invalid indicator: {yaml}"
+    );
+    assert!(
+        yaml.contains("text: \""),
+        "must fall back to double-quoted style: {yaml}"
+    );
+
+    let back: BTreeMap<String, String> = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(back, input);
+}
+
+#[test]
 fn commented_auto_literal_block_keeps_inline_comment_on_header() {
     use std::collections::BTreeMap;
 

--- a/tests/test_prefer_block_scalars.rs
+++ b/tests/test_prefer_block_scalars.rs
@@ -106,3 +106,164 @@ fn prefer_block_scalars_does_not_emit_literal_non_printable_chars() {
     let back: Foo = serde_saphyr::from_str(&out).unwrap();
     assert_eq!(back, value);
 }
+
+#[test]
+fn auto_literal_block_allows_colon_in_multiline_content() {
+    use std::collections::BTreeMap;
+
+    let mut input = BTreeMap::new();
+    input.insert(
+        "python".to_string(),
+        "def foo():\n    print(42)\n".to_string(),
+    );
+
+    let yaml = serde_saphyr::to_string(&input).unwrap();
+
+    assert!(
+        yaml.contains("python: |"),
+        "expected literal block scalar, got:\n{yaml}"
+    );
+    assert!(
+        yaml.contains("def foo():"),
+        "colon must appear literally inside block content, got:\n{yaml}"
+    );
+
+    let back: BTreeMap<String, String> = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(back, input);
+}
+
+#[test]
+fn auto_literal_block_allows_yaml_like_content_without_injection() {
+    use std::collections::BTreeMap;
+
+    let text = "---\nadmin: true\n# this is content\n&anchor\n!tag\nkey: value\n";
+
+    let mut input = BTreeMap::new();
+    input.insert("payload".to_string(), text.to_string());
+
+    let yaml = serde_saphyr::to_string(&input).unwrap();
+
+    assert!(
+        yaml.contains("payload: |"),
+        "expected literal block scalar, got:\n{yaml}"
+    );
+
+    let back: BTreeMap<String, String> = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(back, input);
+}
+
+#[test]
+fn block_scalar_auto_rejects_carriage_return() {
+    use std::collections::BTreeMap;
+
+    let mut input = BTreeMap::new();
+    input.insert("text".to_string(), "a\rb\n".to_string());
+
+    let yaml = serde_saphyr::to_string(&input).unwrap();
+
+    assert!(
+        !yaml.contains("text: |"),
+        "CR must not be emitted literally in block scalar:\n{yaml}"
+    );
+    assert!(
+        yaml.contains("\\r"),
+        "CR should be preserved by quoting/escaping:\n{yaml}"
+    );
+
+    let back: BTreeMap<String, String> = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(back, input);
+}
+
+#[test]
+fn block_scalar_auto_rejects_bom() {
+    use std::collections::BTreeMap;
+
+    let mut input = BTreeMap::new();
+    input.insert("text".to_string(), "before\u{FEFF}after\nmore\n".to_string());
+
+    let yaml = serde_saphyr::to_string(&input).unwrap();
+
+    assert!(
+        !yaml.contains("text: |"),
+        "BOM must not be emitted literally in block scalar:\n{yaml}"
+    );
+    assert!(
+        !yaml.as_bytes().windows(3).any(|w| w == [0xEF, 0xBB, 0xBF]),
+        "BOM should not appear as raw UTF-8 in output:\n{yaml}"
+    );
+
+    let back: BTreeMap<String, String> = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(back, input);
+}
+
+#[test]
+fn block_scalar_auto_rejects_trailing_whitespace_before_newline() {
+    // Trailing whitespace before a newline survives a strict round-trip via the
+    // double-quoted path, but is routinely stripped by editors and tooling when
+    // emitted as a literal block. Auto-selection must therefore prefer quoting.
+    use std::collections::BTreeMap;
+
+    let mut input = BTreeMap::new();
+    input.insert("text".to_string(), "alpha \nbeta\n".to_string());
+
+    let yaml = serde_saphyr::to_string(&input).unwrap();
+
+    assert!(
+        !yaml.contains("text: |"),
+        "trailing whitespace before newline must not auto-select literal block:\n{yaml}"
+    );
+
+    let back: BTreeMap<String, String> = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(back, input);
+}
+
+#[test]
+fn nested_literal_block_with_leading_space_round_trips() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Outer {
+        inner: Inner,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Inner {
+        text: String,
+    }
+
+    let input = Outer {
+        inner: Inner {
+            text: " leading space\nnext line\n".to_string(),
+        },
+    };
+
+    let yaml = serde_saphyr::to_string(&input).unwrap();
+    let back: Outer = serde_saphyr::from_str(&yaml).expect("round-trip parse failed");
+    assert_eq!(back, input);
+}
+
+#[test]
+fn deeply_nested_literal_block_with_leading_space_round_trips() {
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct A {
+        b: B,
+    }
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct B {
+        c: C,
+    }
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct C {
+        text: String,
+    }
+
+    let input = A {
+        b: B {
+            c: C {
+                text: " leading\nsecond\n".to_string(),
+            },
+        },
+    };
+
+    let yaml = serde_saphyr::to_string(&input).unwrap();
+    let back: A = serde_saphyr::from_str(&yaml).expect("deeply nested round-trip parse failed");
+    assert_eq!(back, input);
+}

--- a/tests/test_prefer_block_scalars.rs
+++ b/tests/test_prefer_block_scalars.rs
@@ -197,10 +197,10 @@ fn block_scalar_auto_rejects_bom() {
 }
 
 #[test]
-fn block_scalar_auto_rejects_trailing_whitespace_before_newline() {
-    // Trailing whitespace before a newline survives a strict round-trip via the
-    // double-quoted path, but is routinely stripped by editors and tooling when
-    // emitted as a literal block. Auto-selection must therefore prefer quoting.
+fn auto_literal_block_allows_trailing_whitespace_before_newline() {
+    // YAML block scalars preserve trailing spaces/tabs on content lines, so
+    // there is no safety reason to quote them. Editor/tooling whitespace
+    // stripping is a presentation concern, not a serializer concern.
     use std::collections::BTreeMap;
 
     let mut input = BTreeMap::new();
@@ -209,8 +209,8 @@ fn block_scalar_auto_rejects_trailing_whitespace_before_newline() {
     let yaml = serde_saphyr::to_string(&input).unwrap();
 
     assert!(
-        !yaml.contains("text: |"),
-        "trailing whitespace before newline must not auto-select literal block:\n{yaml}"
+        yaml.contains("text: |"),
+        "trailing whitespace is not a reason to avoid literal block style:\n{yaml}"
     );
 
     let back: BTreeMap<String, String> = serde_saphyr::from_str(&yaml).unwrap();
@@ -287,6 +287,34 @@ fn anchored_auto_literal_block_emits_anchor_before_block_scalar() {
     assert_eq!(parsed[1]["text"], "def foo():\n    print(42)\n");
     assert_eq!(parsed[0]["next"], "after first");
     assert_eq!(parsed[1]["next"], "after second");
+}
+
+#[test]
+fn commented_auto_literal_block_keeps_inline_comment_on_header() {
+    use std::collections::BTreeMap;
+
+    use serde_saphyr::Commented;
+
+    #[derive(Serialize)]
+    struct Wrap {
+        text: Commented<String>,
+    }
+
+    let input_text = "def foo():\n    print(42)\n".to_string();
+
+    let value = Wrap {
+        text: Commented(input_text.clone(), "python body".to_string()),
+    };
+
+    let yaml = serde_saphyr::to_string(&value).unwrap();
+
+    assert!(
+        yaml.contains("text: | # python body\n"),
+        "inline comment should be attached to the block scalar header:\n{yaml}"
+    );
+
+    let back: BTreeMap<String, String> = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(back["text"], input_text);
 }
 
 #[test]


### PR DESCRIPTION
fix(ser): correct block-scalar auto-selection and indentation indicator

Three related fixes around literal block scalar emission:

1. Auto-select block style for any safe multiline content. Previously short
   multiline strings were gated by `is_plain_value_safe(&normalized, ...)`,
   which rejected useful block content like "def foo():\n    print(42)\n"
   because the normalized form "def foo(): print(42)" contained ": ". Long
   multiline strings already used literal block regardless, making the split
   inconsistent. The new gate uses `is_block_scalar_content_safe` (character
   safety) plus `is_auto_block_scalar_readable` (policy: non-empty, no
   trailing whitespace before a newline).

2. Tighten `is_block_scalar_content_safe`: also reject U+FEFF, which is
   excluded from YAML 1.2's `nb-char` production. CR/NEL/LS/PS were already
   rejected.

3. Fix the explicit indentation indicator computation. Per YAML 1.2 §8.1.1.1
   the indicator is the additional indent beyond the parent node, not the
   absolute column. Nested block scalars whose content had leading
   whitespace were emitted with `|4`/`|6` etc. and failed to round-trip
   ("wrongly indented line in block scalar"). The indicator is now
   `indent_step` (the body is exactly one serializer step deeper than the
   parent), which renders correctly for any nesting depth.

Also fixes the originally reported NUL-byte issue: long multiline strings
auto-selected literal block before checking content safety, so a string
like "\n\0..." was emitted with a literal NUL. The post-selection guard
now falls back to the double-quoted path.

Tests cover: colons in block content, YAML-like content (---, anchors,
tags) without injection, rejection of CR/BOM/trailing-whitespace, and
round-trip for nested and deeply-nested values with leading-space content.