### PR TITLE
Fix "last wins"

### DIFF
--- a/src/de/commented_deser.rs
+++ b/src/de/commented_deser.rs
@@ -1,5 +1,7 @@
 //! Internal support for deserializing `Commented<T>`.
 
+use std::borrow::Cow;
+
 use serde::de::{self, IntoDeserializer, Visitor};
 
 use super::Error;
@@ -47,17 +49,18 @@ where
     })
 }
 
-fn joined_comments(comments: Vec<String>) -> String {
+fn joined_comments(comments: Vec<Cow<'_, str>>) -> String {
     comments
         .into_iter()
         .filter(|comment| !comment.is_empty())
+        .map(Cow::into_owned)
         .collect::<Vec<_>>()
         .join("\n")
 }
 
 struct CommentedSeqAccess<'de, 'e> {
     de: Deserializer<'de, 'e>,
-    comments: Vec<String>,
+    comments: Vec<Cow<'de, str>>,
     defer_value_comments: bool,
     state: u8,
 }

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -11,8 +11,9 @@ use super::commented_deser;
 use super::error::{Error, MissingFieldLocationGuard, TransformReason};
 use super::events::{Ev, Events, ReplayEvents, attach_alias_locations_if_missing, eof_with_loc};
 use super::key_nodes::{
-    KeyFingerprint, KeyNode, PendingEntry, capture_node, capture_simple_tagged_node_as_map_events,
-    is_merge_key, one_entry_map_spans, pending_entries_from_live_events, simple_tagged_enum_name,
+    KeyFingerprint, KeyNode, PendingEntry, apply_duplicate_key_policy_to_entries, capture_node,
+    capture_simple_tagged_node_as_map_events, is_merge_key, one_entry_map_spans,
+    pending_entries_from_live_events, simple_tagged_enum_name,
     validate_no_merge_keys_in_node_events,
 };
 use super::options::{DuplicateKeyPolicy, MergeKeyPolicy};
@@ -1443,29 +1444,10 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
             );
         }
 
-        fn keep_last_explicit_entries<'de>(
-            entries: Vec<PendingEntry<'de>>,
-            merge_keys: MergeKeyPolicy,
-        ) -> Result<Vec<PendingEntry<'de>>, Error> {
-            let mut seen = FastHashSet::with_capacity(entries.len());
-            let mut kept = Vec::with_capacity(entries.len());
-
-            for entry in entries.into_iter().rev() {
-                let fingerprint = entry.key.fingerprint().into_owned();
-                if seen.insert(fingerprint) {
-                    kept.push(entry);
-                } else if matches!(merge_keys, MergeKeyPolicy::Error) {
-                    validate_no_merge_keys_in_node_events(entry.value.events())?;
-                }
-            }
-
-            kept.reverse();
-            Ok(kept)
-        }
-
         fn collect_struct_last_wins_entries<'de>(
             ev: &mut dyn Events<'de>,
             mut first_key_comments: Vec<String>,
+            duplicate_keys: DuplicateKeyPolicy,
             merge_keys: MergeKeyPolicy,
         ) -> Result<VecDeque<PendingEntry<'de>>, Error> {
             let mut explicit_entries = Vec::new();
@@ -1491,6 +1473,7 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
                                         ev,
                                         merge_ref_loc,
                                         merge_keys,
+                                        duplicate_keys,
                                     )?;
                                     if !entries.is_empty() {
                                         merge_batches.push(entries);
@@ -1525,7 +1508,11 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
                 }
             }
 
-            let mut explicit_entries = keep_last_explicit_entries(explicit_entries, merge_keys)?;
+            let mut explicit_entries = apply_duplicate_key_policy_to_entries(
+                explicit_entries,
+                duplicate_keys,
+                merge_keys,
+            )?;
             let mut seen = FastHashSet::with_capacity(explicit_entries.len());
             for entry in &explicit_entries {
                 seen.insert(entry.key.fingerprint().into_owned());
@@ -1868,6 +1855,7 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
                                             self.ev,
                                             merge_ref_loc,
                                             self.cfg.merge_keys,
+                                            self.cfg.dup_policy,
                                         )?;
                                         if !entries.is_empty() {
                                             self.merge_stack.push(entries);
@@ -2145,17 +2133,21 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
             }
         }
 
-        let (pending, pending_first_key_comments, live_done) = if self.struct_mode
-            && matches!(self.cfg.dup_policy, DuplicateKeyPolicy::LastWins)
-        {
-            (
-                collect_struct_last_wins_entries(self.ev, map_start_comments, self.cfg.merge_keys)?,
-                Vec::new(),
-                true,
-            )
-        } else {
-            (VecDeque::new(), map_start_comments, false)
-        };
+        let (pending, pending_first_key_comments, live_done) =
+            if self.struct_mode && matches!(self.cfg.dup_policy, DuplicateKeyPolicy::LastWins) {
+                (
+                    collect_struct_last_wins_entries(
+                        self.ev,
+                        map_start_comments,
+                        self.cfg.dup_policy,
+                        self.cfg.merge_keys,
+                    )?,
+                    Vec::new(),
+                    true,
+                )
+            } else {
+                (VecDeque::new(), map_start_comments, false)
+            };
 
         #[cfg(any(feature = "garde", feature = "validator"))]
         let garde = self.garde;

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -91,11 +91,11 @@ pub struct YamlDeserializer<'de, 'e> {
     /// True when the recorded key node was exactly an empty mapping (MapStart followed by MapEnd).
     key_empty_map_node: bool,
     /// Comments that the parent mapping associated with this value.
-    pub(super) pending_comments: Vec<String>,
+    pub(super) pending_comments: Vec<Cow<'de, str>>,
     /// Same-line comments after the parent container separator (`key:` or `-`).
-    pub(super) pending_value_separator_comments: Vec<String>,
+    pub(super) pending_value_separator_comments: Vec<Cow<'de, str>>,
     /// Comments that appeared above the value node itself.
-    pub(super) pending_value_comments: Vec<String>,
+    pub(super) pending_value_comments: Vec<Cow<'de, str>>,
 
     #[cfg(any(feature = "garde", feature = "validator"))]
     garde: Option<&'e mut PathRecorder>,
@@ -1258,7 +1258,7 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
         struct SA<'de, 'e> {
             ev: &'e mut dyn Events<'de>,
             cfg: Cfg,
-            pending_first_element_comments: Vec<String>,
+            pending_first_element_comments: Vec<Cow<'de, str>>,
 
             #[cfg(any(feature = "garde", feature = "validator"))]
             garde: Option<&'e mut PathRecorder>,
@@ -1446,7 +1446,7 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
 
         fn collect_struct_last_wins_entries<'de>(
             ev: &mut dyn Events<'de>,
-            mut first_key_comments: Vec<String>,
+            mut first_key_comments: Vec<Cow<'de, str>>,
             duplicate_keys: DuplicateKeyPolicy,
             merge_keys: MergeKeyPolicy,
         ) -> Result<VecDeque<PendingEntry<'de>>, Error> {
@@ -1555,10 +1555,10 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
             flushing_merges: bool,
             live_done: bool,
             pending_value: Option<(Vec<Ev<'de>>, Location)>,
-            pending_field_comments: Vec<String>,
-            pending_value_separator_comments: Vec<String>,
-            pending_value_comments: Vec<String>,
-            pending_first_key_comments: Vec<String>,
+            pending_field_comments: Vec<Cow<'de, str>>,
+            pending_value_separator_comments: Vec<Cow<'de, str>>,
+            pending_value_comments: Vec<Cow<'de, str>>,
+            pending_first_key_comments: Vec<Cow<'de, str>>,
         }
 
         impl<'de, 'e> MA<'de, 'e> {

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -82,6 +82,11 @@ pub struct YamlDeserializer<'de, 'e> {
     pub(super) cfg: Cfg,
     /// True when deserializing a map key.
     in_key: bool,
+    /// True when Serde entered through `deserialize_struct`.
+    ///
+    /// Derived struct visitors reject repeated fields themselves, so `LastWins`
+    /// needs duplicate fields collapsed before they reach Serde.
+    struct_mode: bool,
     /// True when the recorded key node was exactly an empty mapping (MapStart followed by MapEnd).
     key_empty_map_node: bool,
     /// Comments that the parent mapping associated with this value.
@@ -235,6 +240,7 @@ impl<'de, 'e> YamlDeserializer<'de, 'e> {
             ev,
             cfg,
             in_key: false,
+            struct_mode: false,
             key_empty_map_node: false,
             pending_comments: Vec::new(),
             pending_value_separator_comments: Vec::new(),
@@ -292,6 +298,7 @@ impl<'de, 'e> YamlDeserializer<'de, 'e> {
             ev,
             cfg,
             in_key: false,
+            struct_mode: false,
             key_empty_map_node: false,
             pending_comments: Vec::new(),
             pending_value_separator_comments: Vec::new(),
@@ -1436,6 +1443,108 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
             );
         }
 
+        fn keep_last_explicit_entries<'de>(
+            entries: Vec<PendingEntry<'de>>,
+            merge_keys: MergeKeyPolicy,
+        ) -> Result<Vec<PendingEntry<'de>>, Error> {
+            let mut seen = FastHashSet::with_capacity(entries.len());
+            let mut kept = Vec::with_capacity(entries.len());
+
+            for entry in entries.into_iter().rev() {
+                let fingerprint = entry.key.fingerprint().into_owned();
+                if seen.insert(fingerprint) {
+                    kept.push(entry);
+                } else if matches!(merge_keys, MergeKeyPolicy::Error) {
+                    validate_no_merge_keys_in_node_events(entry.value.events())?;
+                }
+            }
+
+            kept.reverse();
+            Ok(kept)
+        }
+
+        fn collect_struct_last_wins_entries<'de>(
+            ev: &mut dyn Events<'de>,
+            mut first_key_comments: Vec<String>,
+            merge_keys: MergeKeyPolicy,
+        ) -> Result<VecDeque<PendingEntry<'de>>, Error> {
+            let mut explicit_entries = Vec::new();
+            let mut merge_batches = Vec::new();
+
+            loop {
+                match ev.peek()? {
+                    Some(Ev::MapEnd { .. }) => {
+                        let _ = ev.next()?;
+                        break;
+                    }
+                    Some(_) => {
+                        let mut key_comments = std::mem::take(&mut first_key_comments);
+                        key_comments.extend(ev.take_leading_comments_for_next_node()?);
+                        let key = capture_node(ev)?;
+
+                        if is_merge_key(&key) {
+                            match merge_keys {
+                                MergeKeyPolicy::Merge => {
+                                    let _ = ev.peek()?;
+                                    let merge_ref_loc = ev.reference_location();
+                                    let entries = pending_entries_from_live_events(
+                                        ev,
+                                        merge_ref_loc,
+                                        merge_keys,
+                                    )?;
+                                    if !entries.is_empty() {
+                                        merge_batches.push(entries);
+                                    }
+                                    continue;
+                                }
+                                MergeKeyPolicy::AsOrdinary => {}
+                                MergeKeyPolicy::Error => {
+                                    return Err(Error::MergeKeyNotAllowed {
+                                        location: key.location(),
+                                    });
+                                }
+                            }
+                        }
+
+                        let field_comments = key_comments;
+                        let value_separator_comments =
+                            ev.take_separator_comments_before_mapping_value()?;
+                        let value_comments = ev.take_leading_comments_for_next_node()?;
+                        let reference_location = ev.reference_location();
+                        let value = capture_node(ev)?;
+                        explicit_entries.push(PendingEntry {
+                            key,
+                            value,
+                            reference_location,
+                            field_comments,
+                            value_separator_comments,
+                            value_comments,
+                        });
+                    }
+                    None => return Err(eof_with_loc(ev)),
+                }
+            }
+
+            let mut explicit_entries = keep_last_explicit_entries(explicit_entries, merge_keys)?;
+            let mut seen = FastHashSet::with_capacity(explicit_entries.len());
+            for entry in &explicit_entries {
+                seen.insert(entry.key.fingerprint().into_owned());
+            }
+
+            let mut merge_entries = Vec::new();
+            while let Some(batch) = merge_batches.pop() {
+                for entry in batch {
+                    let fingerprint = entry.key.fingerprint().into_owned();
+                    if seen.insert(fingerprint) {
+                        merge_entries.push(entry);
+                    }
+                }
+            }
+
+            explicit_entries.extend(merge_entries);
+            Ok(explicit_entries.into_iter().collect())
+        }
+
         /// Streaming `MapAccess` over the underlying `Events`.
         struct MA<'de, 'e> {
             ev: &'e mut dyn Events<'de>,
@@ -1457,6 +1566,7 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
             pending: VecDeque<PendingEntry<'de>>,
             merge_stack: Vec<Vec<PendingEntry<'de>>>,
             flushing_merges: bool,
+            live_done: bool,
             pending_value: Option<(Vec<Ev<'de>>, Location)>,
             pending_field_comments: Vec<String>,
             pending_value_separator_comments: Vec<String>,
@@ -1535,6 +1645,7 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
                     ev: &mut replay,
                     cfg: self.cfg,
                     in_key: true,
+                    struct_mode: false,
                     key_empty_map_node: kemn,
                     pending_comments: Vec::new(),
                     pending_value_separator_comments: Vec::new(),
@@ -1711,11 +1822,16 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
                         return Ok(Some(key_value));
                     }
 
+                    if self.live_done {
+                        return Ok(None);
+                    }
+
                     if self.flushing_merges {
                         if self.enqueue_next_merge_batch() {
                             continue;
                         }
                         self.flushing_merges = false;
+                        self.live_done = true;
                         return Ok(None);
                     }
 
@@ -1723,6 +1839,7 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
                         Some(Ev::MapEnd { .. }) => {
                             let _ = self.ev.next()?; // consume end
                             if self.merge_stack.is_empty() {
+                                self.live_done = true;
                                 return Ok(None);
                             }
                             self.flushing_merges = true;
@@ -1730,6 +1847,7 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
                                 continue;
                             }
                             self.flushing_merges = false;
+                            self.live_done = true;
                             return Ok(None);
                         }
                         Some(_) => {
@@ -2027,6 +2145,18 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
             }
         }
 
+        let (pending, pending_first_key_comments, live_done) = if self.struct_mode
+            && matches!(self.cfg.dup_policy, DuplicateKeyPolicy::LastWins)
+        {
+            (
+                collect_struct_last_wins_entries(self.ev, map_start_comments, self.cfg.merge_keys)?,
+                Vec::new(),
+                true,
+            )
+        } else {
+            (VecDeque::new(), map_start_comments, false)
+        };
+
         #[cfg(any(feature = "garde", feature = "validator"))]
         let garde = self.garde;
 
@@ -2043,14 +2173,15 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
             pending_path_segment: None,
 
             seen: FastHashSet::with_capacity(8),
-            pending: VecDeque::new(),
+            pending,
             merge_stack: Vec::new(),
             flushing_merges: false,
+            live_done,
             pending_value: None,
             pending_field_comments: Vec::new(),
             pending_value_separator_comments: Vec::new(),
             pending_value_comments: Vec::new(),
-            pending_first_key_comments: map_start_comments,
+            pending_first_key_comments,
         })
     }
 
@@ -2067,7 +2198,9 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
         _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        self.deserialize_map(visitor)
+        let mut de = self;
+        de.struct_mode = true;
+        de.deserialize_map(visitor)
     }
 
     /// Deserialize an externally-tagged enum in either `Variant` or `{ Variant: value }` form.

--- a/src/de/events.rs
+++ b/src/de/events.rs
@@ -181,7 +181,7 @@ pub(crate) trait Events<'de> {
     /// for replay buffers that do not carry presentation metadata. If a caller
     /// needs comments for a captured node, it must take them from the live stream
     /// before calling `capture_node` and carry them separately.
-    fn take_leading_comments_for_next_node(&mut self) -> Result<Vec<String>, Error> {
+    fn take_leading_comments_for_next_node(&mut self) -> Result<Vec<Cow<'de, str>>, Error> {
         Ok(Vec::new())
     }
 
@@ -190,7 +190,9 @@ pub(crate) trait Events<'de> {
     /// This is the `# comment` in `key: # comment`, separated from comments
     /// immediately above the value node so nested containers do not treat the
     /// separator comment as a child-key comment.
-    fn take_separator_comments_before_mapping_value(&mut self) -> Result<Vec<String>, Error> {
+    fn take_separator_comments_before_mapping_value(
+        &mut self,
+    ) -> Result<Vec<Cow<'de, str>>, Error> {
         Ok(Vec::new())
     }
 
@@ -198,12 +200,14 @@ pub(crate) trait Events<'de> {
     ///
     /// This is the `# comment` in `- # comment`, separated from ordinary
     /// trailing comments after the previous sequence value.
-    fn take_separator_comments_before_sequence_item_value(&mut self) -> Result<Vec<String>, Error> {
+    fn take_separator_comments_before_sequence_item_value(
+        &mut self,
+    ) -> Result<Vec<Cow<'de, str>>, Error> {
         Ok(Vec::new())
     }
 
     /// Take same-line comments immediately after the node that was just deserialized.
-    fn take_trailing_comments_after_node(&mut self) -> Result<Vec<String>, Error> {
+    fn take_trailing_comments_after_node(&mut self) -> Result<Vec<Cow<'de, str>>, Error> {
         Ok(Vec::new())
     }
 

--- a/src/de/key_nodes.rs
+++ b/src/de/key_nodes.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 #[cfg(feature = "properties")]
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::mem;
 #[cfg(feature = "properties")]
 use std::rc::Rc;
@@ -9,7 +10,7 @@ use granit_parser::ScalarStyle;
 
 use super::error::Error;
 use super::events::{Ev, Events, ReplayEvents};
-use super::options::MergeKeyPolicy;
+use super::options::{DuplicateKeyPolicy, MergeKeyPolicy};
 use super::tags::SfTag;
 use crate::location::Location;
 use crate::parse_scalars::scalar_is_nullish;
@@ -576,6 +577,48 @@ pub(super) fn validate_no_merge_keys_in_node_events(events: &[Ev<'_>]) -> Result
     }
 }
 
+pub(super) fn apply_duplicate_key_policy_to_entries(
+    mut entries: Vec<PendingEntry>,
+    duplicate_keys: DuplicateKeyPolicy,
+    merge_keys: MergeKeyPolicy,
+) -> Result<Vec<PendingEntry>, Error> {
+    let last_wins = matches!(duplicate_keys, DuplicateKeyPolicy::LastWins);
+    if last_wins {
+        entries.reverse();
+    }
+
+    let mut seen = HashSet::with_capacity(entries.len());
+    let mut kept = Vec::with_capacity(entries.len());
+
+    for entry in entries {
+        if seen.insert(entry.key.fingerprint().into_owned()) {
+            kept.push(entry);
+            continue;
+        }
+
+        if matches!(duplicate_keys, DuplicateKeyPolicy::Error) {
+            // This is an error path. We would rather get the fingerprint
+            // a second time here for error reporting than clone it before.
+            let fingerprint = entry.key.fingerprint();
+            let key = fingerprint.stringy_scalar_value().map(ToOwned::to_owned);
+            return Err(Error::DuplicateMappingKey {
+                key,
+                location: entry.key.location(),
+            });
+        }
+
+        if matches!(merge_keys, MergeKeyPolicy::Error) {
+            validate_no_merge_keys_in_node_events(entry.value.events())?;
+        }
+    }
+
+    if last_wins {
+        kept.reverse();
+    }
+
+    Ok(kept)
+}
+
 /// Expand a merge value node into a queue of `PendingEntry`s in correct order.
 ///
 /// Arguments:
@@ -593,6 +636,7 @@ pub(super) fn pending_entries_from_events<'a>(
     location: Location,
     reference_location: Location,
     merge_keys: MergeKeyPolicy,
+    duplicate_keys: DuplicateKeyPolicy,
     #[cfg(feature = "properties")] property_map: Option<Rc<HashMap<String, String>>>,
 ) -> Result<Vec<PendingEntry<'a>>, Error> {
     let mut replay = ReplayEvents::with_reference(
@@ -609,7 +653,7 @@ pub(super) fn pending_entries_from_events<'a>(
             location: *location,
         }),
         Some(Ev::MapStart { .. }) => {
-            collect_entries_from_map(&mut replay, reference_location, merge_keys)
+            collect_entries_from_map(&mut replay, reference_location, merge_keys, duplicate_keys)
         }
         Some(Ev::SeqStart { .. }) => {
             let mut batches = Vec::new();
@@ -632,6 +676,7 @@ pub(super) fn pending_entries_from_events<'a>(
                             element.location(),
                             element_ref_loc,
                             merge_keys,
+                            duplicate_keys,
                             #[cfg(feature = "properties")]
                             property_map.clone(),
                         )?); // recursive
@@ -671,6 +716,7 @@ pub(super) fn pending_entries_from_live_events<'a>(
     ev: &mut dyn Events<'a>,
     merge_reference_location: Location,
     merge_keys: MergeKeyPolicy,
+    duplicate_keys: DuplicateKeyPolicy,
 ) -> Result<Vec<PendingEntry<'a>>, Error> {
     #[cfg(feature = "properties")]
     let property_map = ev.property_map().map(Rc::clone);
@@ -689,6 +735,7 @@ pub(super) fn pending_entries_from_live_events<'a>(
                 node.location(),
                 merge_reference_location,
                 merge_keys,
+                duplicate_keys,
                 #[cfg(feature = "properties")]
                 property_map,
             )
@@ -711,6 +758,7 @@ pub(super) fn pending_entries_from_live_events<'a>(
                             element.location(),
                             element_ref_loc,
                             merge_keys,
+                            duplicate_keys,
                             #[cfg(feature = "properties")]
                             property_map.clone(),
                         )?);
@@ -745,6 +793,7 @@ pub(super) fn collect_entries_from_map<'a>(
     ev: &mut dyn Events<'a>,
     reference_location: Location,
     merge_keys: MergeKeyPolicy,
+    duplicate_keys: DuplicateKeyPolicy,
 ) -> Result<Vec<PendingEntry<'a>>, Error> {
     let Some(Ev::MapStart { .. }) = ev.next()? else {
         return Err(Error::MergeValueNotMapOrSeqOfMaps {
@@ -776,6 +825,7 @@ pub(super) fn collect_entries_from_map<'a>(
                                 ev,
                                 merge_ref_loc,
                                 merge_keys,
+                                duplicate_keys,
                             )?);
                             continue;
                         }
@@ -806,7 +856,7 @@ pub(super) fn collect_entries_from_map<'a>(
         }
     }
 
-    let mut entries = fields;
+    let mut entries = apply_duplicate_key_policy_to_entries(fields, duplicate_keys, merge_keys)?;
     while let Some(mut nested) = merges.pop() {
         entries.append(&mut nested);
     }

--- a/src/de/key_nodes.rs
+++ b/src/de/key_nodes.rs
@@ -173,11 +173,11 @@ pub(super) struct PendingEntry<'a> {
     /// For replayed entries these are comments captured at the use site while
     /// scanning the containing map. Definition-site comments inside an anchored
     /// mapping are not reconstructed from the recorded event buffer.
-    pub(super) field_comments: Vec<String>,
+    pub(super) field_comments: Vec<Cow<'a, str>>,
     /// Same-line comments after the key/value separator.
-    pub(super) value_separator_comments: Vec<String>,
+    pub(super) value_separator_comments: Vec<Cow<'a, str>>,
     /// Comments immediately above the value node.
-    pub(super) value_comments: Vec<String>,
+    pub(super) value_comments: Vec<Cow<'a, str>>,
 }
 
 /// Return the span lengths of key and value for a one-entry map encoded in `events`.

--- a/src/de/live_events.rs
+++ b/src/de/live_events.rs
@@ -91,8 +91,8 @@ enum PendingTrailingCommentKind {
 }
 
 #[derive(Debug)]
-struct PendingTrailingComment {
-    text: String,
+struct PendingTrailingComment<'a> {
+    text: Cow<'a, str>,
     kind: PendingTrailingCommentKind,
 }
 
@@ -183,14 +183,14 @@ pub(crate) struct LiveEvents<'a> {
     /// Single-item lookahead buffer (peeked event not yet consumed).
     look: Option<Ev<'a>>,
     /// Comments immediately above the lookahead event.
-    look_leading_comments: Vec<String>,
+    look_leading_comments: Vec<Cow<'a, str>>,
     /// Comments gathered while scanning before the next data event.
-    pending_leading_comments: Vec<String>,
+    pending_leading_comments: Vec<Cow<'a, str>>,
     /// Right-side comments pending until a caller claims them or the next data
     /// event is consumed.
-    pending_trailing_comments: Vec<PendingTrailingComment>,
+    pending_trailing_comments: Vec<PendingTrailingComment<'a>>,
     /// Comments attached to the event most recently produced by `next_impl`.
-    produced_leading_comments: Vec<String>,
+    produced_leading_comments: Vec<Cow<'a, str>>,
     /// For alias replay: a stack of injected buffers; we always read from the top first.
     inject: Vec<InjectFrame>,
     /// Recorded buffers for anchors (index = anchor_id).
@@ -440,8 +440,18 @@ impl<'a> LiveEvents<'a> {
         }
     }
 
-    fn normalize_comment_text(text: Cow<'a, str>) -> String {
-        text.trim().to_owned()
+    fn normalize_comment_text(text: Cow<'a, str>) -> Cow<'a, str> {
+        match text {
+            Cow::Borrowed(text) => Cow::Borrowed(text.trim()),
+            Cow::Owned(text) => {
+                let trimmed = text.trim();
+                if trimmed.len() == text.len() {
+                    Cow::Owned(text)
+                } else {
+                    Cow::Owned(trimmed.to_owned())
+                }
+            }
+        }
     }
 
     fn event_kind(ev: &Ev<'_>) -> Option<ConsumedEventKind> {
@@ -484,7 +494,7 @@ impl<'a> LiveEvents<'a> {
     fn take_pending_trailing_comments_where(
         &mut self,
         mut predicate: impl FnMut(PendingTrailingCommentKind) -> bool,
-    ) -> Vec<String> {
+    ) -> Vec<Cow<'a, str>> {
         let mut taken = Vec::new();
         let mut retained = Vec::new();
 
@@ -500,7 +510,7 @@ impl<'a> LiveEvents<'a> {
         taken
     }
 
-    fn take_all_pending_trailing_comments(&mut self) -> Vec<String> {
+    fn take_all_pending_trailing_comments(&mut self) -> Vec<Cow<'a, str>> {
         std::mem::take(&mut self.pending_trailing_comments)
             .into_iter()
             .map(|comment| comment.text)
@@ -1174,24 +1184,28 @@ impl<'de> Events<'de> for LiveEvents<'de> {
             .unwrap_or(self.last_location)
     }
 
-    fn take_leading_comments_for_next_node(&mut self) -> Result<Vec<String>, Error> {
+    fn take_leading_comments_for_next_node(&mut self) -> Result<Vec<Cow<'de, str>>, Error> {
         let _ = self.peek()?;
         Ok(std::mem::take(&mut self.look_leading_comments))
     }
 
-    fn take_separator_comments_before_mapping_value(&mut self) -> Result<Vec<String>, Error> {
+    fn take_separator_comments_before_mapping_value(
+        &mut self,
+    ) -> Result<Vec<Cow<'de, str>>, Error> {
         let _ = self.peek()?;
         Ok(self.take_all_pending_trailing_comments())
     }
 
-    fn take_separator_comments_before_sequence_item_value(&mut self) -> Result<Vec<String>, Error> {
+    fn take_separator_comments_before_sequence_item_value(
+        &mut self,
+    ) -> Result<Vec<Cow<'de, str>>, Error> {
         let _ = self.peek()?;
         Ok(self.take_pending_trailing_comments_where(|kind| {
             kind == PendingTrailingCommentKind::BeforeUpcomingNode
         }))
     }
 
-    fn take_trailing_comments_after_node(&mut self) -> Result<Vec<String>, Error> {
+    fn take_trailing_comments_after_node(&mut self) -> Result<Vec<Cow<'de, str>>, Error> {
         let _ = self.peek()?;
         Ok(self.take_pending_trailing_comments_where(|kind| {
             kind == PendingTrailingCommentKind::AfterConsumedNode

--- a/src/de/options.rs
+++ b/src/de/options.rs
@@ -19,8 +19,9 @@ pub enum DuplicateKeyPolicy {
     Error,
     /// First key wins: later duplicate pairs are skipped (key+value are consumed and ignored).
     FirstWins,
-    /// Last key wins: later duplicate pairs replace earlier ones when deserializing maps,
-    /// and duplicate struct fields are collapsed before Serde sees them.
+    /// Last key wins: duplicate pairs are passed through when deserializing maps
+    /// so overwriting map targets can keep the later value; duplicate struct fields
+    /// are collapsed before Serde sees them.
     LastWins,
 }
 

--- a/src/de/options.rs
+++ b/src/de/options.rs
@@ -19,7 +19,8 @@ pub enum DuplicateKeyPolicy {
     Error,
     /// First key wins: later duplicate pairs are skipped (key+value are consumed and ignored).
     FirstWins,
-    /// Last key wins: later duplicate pairs are passed through (default Serde targets typically overwrite).
+    /// Last key wins: later duplicate pairs replace earlier ones when deserializing maps,
+    /// and duplicate struct fields are collapsed before Serde sees them.
     LastWins,
 }
 

--- a/src/de/tests.rs
+++ b/src/de/tests.rs
@@ -85,7 +85,13 @@ fn pending_from_events(
     location: Location,
     reference_location: Location,
 ) -> Result<Vec<PendingEntry<'static>>, Error> {
-    pending_entries_from_events(events, location, reference_location, MergeKeyPolicy::Merge)
+    pending_entries_from_events(
+        events,
+        location,
+        reference_location,
+        MergeKeyPolicy::Merge,
+        DuplicateKeyPolicy::Error,
+    )
 }
 
 #[cfg(feature = "properties")]
@@ -99,6 +105,7 @@ fn pending_from_events(
         location,
         reference_location,
         MergeKeyPolicy::Merge,
+        DuplicateKeyPolicy::Error,
         None,
     )
 }
@@ -624,9 +631,14 @@ fn pending_entries_from_live_events_handles_null_scalars_sequences_and_eof() {
         loc(29, 1),
     )]);
     assert!(
-        pending_entries_from_live_events(&mut null_replay, merge_reference, MergeKeyPolicy::Merge)
-            .unwrap()
-            .is_empty()
+        pending_entries_from_live_events(
+            &mut null_replay,
+            merge_reference,
+            MergeKeyPolicy::Merge,
+            DuplicateKeyPolicy::Error,
+        )
+        .unwrap()
+        .is_empty()
     );
 
     let mut scalar_replay = replay_events(vec![scalar(
@@ -640,6 +652,7 @@ fn pending_entries_from_live_events_handles_null_scalars_sequences_and_eof() {
         &mut scalar_replay,
         merge_reference,
         MergeKeyPolicy::Merge,
+        DuplicateKeyPolicy::Error,
     ));
     assert!(matches!(
         err,
@@ -658,9 +671,13 @@ fn pending_entries_from_live_events_handles_null_scalars_sequences_and_eof() {
         map_end(loc(32, 5)),
         seq_end(loc(33, 1)),
     ]);
-    let entries =
-        pending_entries_from_live_events(&mut seq_replay, merge_reference, MergeKeyPolicy::Merge)
-            .unwrap();
+    let entries = pending_entries_from_live_events(
+        &mut seq_replay,
+        merge_reference,
+        MergeKeyPolicy::Merge,
+        DuplicateKeyPolicy::Error,
+    )
+    .unwrap();
     assert_eq!(entries.len(), 2);
     assert_eq!(
         pending_pair(&entries[0]),
@@ -676,6 +693,7 @@ fn pending_entries_from_live_events_handles_null_scalars_sequences_and_eof() {
         &mut empty,
         merge_reference,
         MergeKeyPolicy::Merge,
+        DuplicateKeyPolicy::Error,
     ));
     assert!(matches!(err, Error::Eof { location } if location == Location::UNKNOWN));
 }
@@ -693,6 +711,7 @@ fn collect_entries_from_map_expands_merges_and_preserves_reference_locations() {
         &mut not_a_map,
         loc(34, 9),
         MergeKeyPolicy::Merge,
+        DuplicateKeyPolicy::Error,
     ));
     assert!(matches!(
         err,
@@ -713,8 +732,13 @@ fn collect_entries_from_map_expands_merges_and_preserves_reference_locations() {
         map_end(loc(35, 10)),
     ]);
 
-    let entries =
-        collect_entries_from_map(&mut replay, outer_reference, MergeKeyPolicy::Merge).unwrap();
+    let entries = collect_entries_from_map(
+        &mut replay,
+        outer_reference,
+        MergeKeyPolicy::Merge,
+        DuplicateKeyPolicy::Error,
+    )
+    .unwrap();
     assert_eq!(entries.len(), 2);
     assert_eq!(
         pending_pair(&entries[0]),
@@ -736,8 +760,13 @@ fn collect_entries_from_map_treats_merge_key_as_ordinary_under_policy() {
         map_end(loc(36, 4)),
     ]);
 
-    let entries =
-        collect_entries_from_map(&mut replay, reference, MergeKeyPolicy::AsOrdinary).unwrap();
+    let entries = collect_entries_from_map(
+        &mut replay,
+        reference,
+        MergeKeyPolicy::AsOrdinary,
+        DuplicateKeyPolicy::Error,
+    )
+    .unwrap();
 
     assert_eq!(entries.len(), 1);
     assert_eq!(
@@ -759,6 +788,7 @@ fn collect_entries_from_map_rejects_merge_key_under_error_policy() {
         &mut replay,
         loc(37, 9),
         MergeKeyPolicy::Error,
+        DuplicateKeyPolicy::Error,
     ));
 
     assert!(matches!(

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -306,6 +306,46 @@ target:
     }
 
     #[test]
+    fn duplicate_keys_last_wins_struct_treats_merge_key_as_ordinary_when_configured() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct HasMergeLikeField {
+            #[serde(rename = "<<")]
+            merge_like: HashMap<String, String>,
+        }
+
+        let y = r#"
+<<: { color: blue }
+"#;
+
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::LastWins,
+            merge_keys: serde_saphyr::options::MergeKeyPolicy::AsOrdinary,
+        };
+
+        let got = from_str_with_options::<HasMergeLikeField>(y, opt).unwrap();
+        assert_eq!(
+            got.merge_like.get("color").map(String::as_str),
+            Some("blue")
+        );
+    }
+
+    #[test]
+    fn duplicate_keys_last_wins_struct_explicit_field_still_overrides_merge_source() {
+        let y = r#"
+target:
+  <<: { color: red, color: blue }
+  color: green
+"#;
+
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::LastWins,
+        };
+
+        let root = from_str_with_options::<BackgroundRoot>(y, opt).unwrap();
+        assert_eq!(root.target.color, "green");
+    }
+
+    #[test]
     fn duplicate_keys_last_wins_direct_struct_from_aliased_merge_source() {
         let y = r#"
 base: &B { color: red, color: blue }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -215,6 +215,27 @@ plain
         color: String,
     }
 
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct BackgroundRoot {
+        target: Background,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct BackgroundNestedRoot {
+        background: Background,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct BackgroundRootWithBase {
+        base: HashMap<String, String>,
+        target: Background,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum BackgroundNode {
+        Background { color: String },
+    }
+
     #[test]
     fn duplicate_keys_last_wins_direct_struct() {
         let y = "color: red\ncolor: blue\n";
@@ -223,6 +244,31 @@ plain
         };
         let bg = from_str_with_options::<Background>(y, opt).unwrap();
         assert_eq!(bg.color, "blue");
+    }
+
+    #[test]
+    fn duplicate_keys_last_wins_nested_struct() {
+        let y = "background:\n  color: red\n  color: blue\n";
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::LastWins,
+        };
+        let root = from_str_with_options::<BackgroundNestedRoot>(y, opt).unwrap();
+        assert_eq!(root.background.color, "blue");
+    }
+
+    #[test]
+    fn duplicate_keys_last_wins_struct_variant() {
+        let y = "Background:\n  color: red\n  color: blue\n";
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::LastWins,
+        };
+        let node = from_str_with_options::<BackgroundNode>(y, opt).unwrap();
+        assert_eq!(
+            node,
+            BackgroundNode::Background {
+                color: "blue".to_owned(),
+            }
+        );
     }
 
     #[test]
@@ -242,6 +288,61 @@ plain
             duplicate_keys: DuplicateKeyPolicy::Error,
         };
         let err = from_str_with_options::<Background>(y, opt).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("duplicate mapping key: color"));
+    }
+
+    #[test]
+    fn duplicate_keys_last_wins_direct_struct_from_merge_source() {
+        let y = r#"
+target:
+  <<: { color: red, color: blue }
+"#;
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::LastWins,
+        };
+        let root = from_str_with_options::<BackgroundRoot>(y, opt).unwrap();
+        assert_eq!(root.target.color, "blue");
+    }
+
+    #[test]
+    fn duplicate_keys_last_wins_direct_struct_from_aliased_merge_source() {
+        let y = r#"
+base: &B { color: red, color: blue }
+target:
+  <<: *B
+"#;
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::LastWins,
+        };
+        let root = from_str_with_options::<BackgroundRootWithBase>(y, opt).unwrap();
+        assert_eq!(root.base.get("color").map(String::as_str), Some("blue"));
+        assert_eq!(root.target.color, "blue");
+    }
+
+    #[test]
+    fn duplicate_keys_first_wins_direct_struct_from_merge_source() {
+        let y = r#"
+target:
+  <<: { color: red, color: blue }
+"#;
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::FirstWins,
+        };
+        let root = from_str_with_options::<BackgroundRoot>(y, opt).unwrap();
+        assert_eq!(root.target.color, "red");
+    }
+
+    #[test]
+    fn duplicate_keys_error_direct_struct_from_merge_source() {
+        let y = r#"
+target:
+  <<: { color: red, color: blue }
+"#;
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::Error,
+        };
+        let err = from_str_with_options::<BackgroundRoot>(y, opt).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("duplicate mapping key: color"));
     }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -210,6 +210,42 @@ plain
         assert_eq!(m.len(), 2);
     }
 
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Background {
+        color: String,
+    }
+
+    #[test]
+    fn duplicate_keys_last_wins_direct_struct() {
+        let y = "color: red\ncolor: blue\n";
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::LastWins,
+        };
+        let bg = from_str_with_options::<Background>(y, opt).unwrap();
+        assert_eq!(bg.color, "blue");
+    }
+
+    #[test]
+    fn duplicate_keys_first_wins_direct_struct() {
+        let y = "color: red\ncolor: blue\n";
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::FirstWins,
+        };
+        let bg = from_str_with_options::<Background>(y, opt).unwrap();
+        assert_eq!(bg.color, "red");
+    }
+
+    #[test]
+    fn duplicate_keys_error_direct_struct() {
+        let y = "color: red\ncolor: blue\n";
+        let opt = serde_saphyr::options! {
+            duplicate_keys: DuplicateKeyPolicy::Error,
+        };
+        let err = from_str_with_options::<Background>(y, opt).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("duplicate mapping key: color"));
+    }
+
     #[test]
     fn duplicate_sequence_keys_policies() {
         let y = "?\n  - 1\n  - 2\n: first\n?\n  - 1\n  - 2\n: second\n";


### PR DESCRIPTION
Fix #120.

The bug was that DuplicateKeyPolicy::LastWins only worked when the Serde target naturally overwrote duplicate keys, like HashMap or serde_json::Value. For derived structs, Serde itself rejects repeated fields. So serde-saphyr was passing both:

color: red
color: blue

to Serde’s struct visitor, and Serde errored with duplicate field 'color' before "blue" could win.
I changed src/de/deserializer.rs so the deserializer now knows when Serde entered through deserialize_struct. For struct + LastWins only, it buffers that mapping, collapses duplicate explicit fields to the last entry, then feeds Serde only one color field. Normal map deserialization remains streaming.

The key behavior is in src/de/deserializer.rs:
- scan struct mapping entries
- keep the last explicit duplicate by walking entries in reverse
- preserve merge handling and explicit-field precedence
- mark the live stream done after replaying the collapsed pending entries Error and FirstWins still use the existing  streaming path. That means:
- Error reports duplicate mapping key: color
- FirstWins skips the second value and keeps "red"
- LastWins collapses before Serde sees duplicates and keeps "blue"

I also updated the LastWins docs in src/de/options.rs, and added direct struct tests for all three policies in tests/basic_tests.rs.