### PR TITLE
feat(properties): add default parameter expansion (`${Foo:-bar_default}`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,10 +469,15 @@ Many configuration formats contain secret values that should not be part of chec
 
 Interpolation is intentionally narrow in scope:
 
-- it only applies to **plain scalars**,
-- quoted scalars and block scalars stay literal,
+- it only applies to **plain scalars**; quoted scalars and block scalars stay literal,
+- the supported forms are `${NAME}` and `${NAME:-default}`. No other docker-compose modifiers (`:-` is the only one) are supported,
 - `$${NAME}` escapes to a literal `${NAME}`,
-- and if no property map is configured, `${NAME}` remains unchanged instead of being treated specially.
+- if no property map is configured, `${NAME}` and `${NAME:-default}` remain unchanged instead of being treated specially.
+
+For `${NAME:-default}`, the `default` text is used when `NAME` is unset or set to an empty string.
+It is taken verbatim up to the first `}` with no escape processing, so it cannot itself contain a `}`.
+Defaults are treated as ordinary literal text from the YAML source.
+Only values pulled from the property map are tracked for redaction.
 
 That means you can opt in where it is useful without changing the meaning of YAML constructs that are typically expected to remain exact text.
 
@@ -521,7 +526,7 @@ fn property_map_example_works() {
 }
 ```
 
-If interpolation is enabled but a referenced property is missing, or the `${...}` name is invalid, deserialization fails with a dedicated error that points to the YAML source location. This is useful both for correctness and for security: configuration mistakes should fail closed instead of silently producing partial or surprising values.
+If interpolation is enabled but a referenced property is missing and no `${NAME:-default}` was supplied, or the `${...}` name is invalid, deserialization fails with a dedicated error that points to the YAML source location. This is useful both for correctness and for security: configuration mistakes should fail closed instead of silently producing partial or surprising values.
 
 The security aspect matters most when the property values are secrets. Interpolation resolves the final value before Serde finishes deserializing the surrounding type, so downstream custom deserializers, validation code, or other error paths could otherwise end up echoing the resolved secret. `serde-saphyr` tracks interpolated values during deserialization and redacts them back to their original `${NAME}` form in later error messages, reducing the risk of leaking secrets into logs or diagnostics. You should still treat the property map itself as sensitive input and avoid formatting or logging it directly in your application.
 

--- a/src/de/properties.rs
+++ b/src/de/properties.rs
@@ -89,8 +89,8 @@ fn resolve_brace<'a>(
     vars: &'a HashMap<String, String>,
 ) -> Result<&'a str, &'a str> {
     match (vars.get(brace.name).map(String::as_str), brace.default) {
-        (Some(value), _) => Ok(value),
         (None | Some(""), Some(default)) => Ok(default),
+        (Some(value), _) => Ok(value),
         (None, None) => Err(brace.name),
     }
 }

--- a/src/de/properties.rs
+++ b/src/de/properties.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-/// Property interpolation failure reported while scanning a scalar value.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum PropertyError {
-    /// A valid `${NAME}` reference could not be resolved from the property map.
+    /// `${NAME}` had no value in the property map and no default was supplied.
     Unresolved(String),
-    /// A `${...}` candidate was present but did not use a valid property name.
+    /// A `${...}` candidate was present but did not parse as `${NAME}` or
+    /// `${NAME:-default}`. The string is the full candidate including braces.
     InvalidName(String),
 }
 
@@ -40,36 +40,64 @@ fn parse_name(input: &str) -> Option<(&str, &str)> {
     Some((&input[..end], &input[end..]))
 }
 
-/// Parses `${name}` starting at `start`, returning the referenced property name and the end index.
-///
-/// Returns `Err(candidate)` when a braced `${...}` sequence is present but its name is invalid.
-/// Returns `Ok(None)` when the input does not contain a complete braced candidate at `start`.
-fn parse_braced_reference(input: &str, start: usize) -> Result<Option<(&str, usize)>, String> {
+struct BraceRef<'a> {
+    name: &'a str,
+    default: Option<&'a str>,
+}
+
+/// Returns `Err` when the `${...}` candidate is malformed, `Ok(None)` when the brace
+/// isn't closed (treat the `$` as literal), or `Ok(Some(...))` with the parsed reference
+/// and the byte index just past the closing `}`.
+fn parse_braced_reference(
+    input: &str,
+    start: usize,
+) -> Result<Option<(BraceRef<'_>, usize)>, String> {
     let body_start = start + 2;
     let Some(close_rel) = input[body_start..].find('}') else {
         return Ok(None);
     };
     let close = close_rel + body_start;
     let body = &input[body_start..close];
-    let candidate = input[start..close + 1].to_owned();
     let Some((name, rest)) = parse_name(body) else {
-        return Err(candidate);
+        return Err(input[start..close + 1].to_owned());
     };
 
     if rest.is_empty() {
-        Ok(Some((name, close + 1)))
-    } else {
-        Err(candidate)
+        return Ok(Some((
+            BraceRef {
+                name,
+                default: None,
+            },
+            close + 1,
+        )));
     }
+
+    let default_text = rest
+        .strip_prefix(":-")
+        .ok_or_else(|| input[start..close + 1].to_owned())?;
+    Ok(Some((
+        BraceRef {
+            name,
+            default: Some(default_text),
+        },
+        close + 1,
+    )))
 }
 
-/// Parameters:
-/// - `input`: scalar text after YAML parsing, before Serde type conversion.
-/// - `vars`: final caller-supplied property map. Values are treated as final values,
-///   so this function does not recursively expand placeholders inside map entries.
-///
-/// Returns:
-/// - `Cow::Borrowed` when the scalar is unchanged, or `Cow::Owned` with the expanded value.
+fn resolve_brace<'a>(
+    brace: &'a BraceRef<'a>,
+    vars: &'a HashMap<String, String>,
+) -> Result<&'a str, &'a str> {
+    let value = vars
+        .get(brace.name)
+        .map(String::as_str)
+        .filter(|v| !v.is_empty());
+    value.or(brace.default).ok_or(brace.name)
+}
+
+/// Expands `${NAME}` and `${NAME:-default}` references in `input` against `vars`.
+/// Values in `vars` are taken as final, so placeholders inside map entries are not re-expanded.
+/// Returns `Cow::Borrowed` when nothing changed so the common no-`$` path stays allocation-free.
 pub(crate) fn interpolate_compose_style<'s>(
     input: Cow<'s, str>,
     vars: &HashMap<String, String>,
@@ -115,17 +143,15 @@ pub(crate) fn interpolate_compose_style<'s>(
             continue;
         }
 
-        let Some((name, end)) =
+        let Some((brace, end)) =
             parse_braced_reference(input_str, i).map_err(PropertyError::InvalidName)?
         else {
             i += 1;
             continue;
         };
 
-        let value = vars
-            .get(name)
-            .map(String::as_str)
-            .ok_or_else(|| PropertyError::Unresolved(name.to_owned()))?;
+        let value =
+            resolve_brace(&brace, vars).map_err(|n| PropertyError::Unresolved(n.to_owned()))?;
 
         if !changed {
             out.push_str(&input_str[..i]);
@@ -186,11 +212,11 @@ mod tests {
         let vars = HashMap::from([(String::from("NAME"), String::from("world"))]);
 
         let error =
-            interpolate_compose_style(Cow::Borrowed("${NAME:-fallback}"), &vars).unwrap_err();
+            interpolate_compose_style(Cow::Borrowed("${NAME:?fallback}"), &vars).unwrap_err();
 
         assert_eq!(
             error,
-            PropertyError::InvalidName("${NAME:-fallback}".to_string())
+            PropertyError::InvalidName("${NAME:?fallback}".to_string())
         );
     }
 

--- a/src/de/properties.rs
+++ b/src/de/properties.rs
@@ -88,11 +88,11 @@ fn resolve_brace<'a>(
     brace: &'a BraceRef<'a>,
     vars: &'a HashMap<String, String>,
 ) -> Result<&'a str, &'a str> {
-    let value = vars
-        .get(brace.name)
-        .map(String::as_str)
-        .filter(|v| !v.is_empty());
-    value.or(brace.default).ok_or(brace.name)
+    match (vars.get(brace.name).map(String::as_str), brace.default) {
+        (Some(value), _) => Ok(value),
+        (None | Some(""), Some(default)) => Ok(default),
+        (None, None) => Err(brace.name),
+    }
 }
 
 /// Expands `${NAME}` and `${NAME:-default}` references in `input` against `vars`.

--- a/tests/test_properties.rs
+++ b/tests/test_properties.rs
@@ -202,6 +202,39 @@ fn disabled_properties_leave_placeholder_verbatim_without_error() {
 }
 
 #[test]
+fn bare_reference_resolves_explicitly_empty_value_without_default() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct OptValue {
+        value: Option<String>,
+    }
+
+    let mut properties = HashMap::new();
+    properties.insert("EMPTY".to_string(), String::new());
+
+    let parsed: OptValue = from_str_with_options(
+        "value: ${EMPTY}\n",
+        property_options_with_map(Some(properties)),
+    )
+    .unwrap();
+
+    assert_eq!(parsed.value, None);
+}
+
+#[test]
+fn default_form_uses_default_when_property_is_explicitly_empty() {
+    let mut properties = HashMap::new();
+    properties.insert("EMPTY".to_string(), String::new());
+
+    let parsed: ScalarConfig = from_str_with_options(
+        "value: ${EMPTY:-fallback}\n",
+        property_options_with_map(Some(properties)),
+    )
+    .unwrap();
+
+    assert_eq!(parsed.value, "fallback");
+}
+
+#[test]
 fn missing_property_is_an_error_when_properties_are_enabled() {
     let err = from_str_with_options::<ScalarConfig>(
         "value: ${MISSING}\n",

--- a/tests/test_properties.rs
+++ b/tests/test_properties.rs
@@ -253,6 +253,106 @@ fn invalid_property_name_is_an_error_when_properties_are_enabled() {
 }
 
 #[test]
+fn interpolation_works_after_non_ascii_text() {
+    let mut properties = HashMap::new();
+    properties.insert("NAME".to_string(), "world".to_string());
+
+    let parsed: ScalarConfig = from_str_with_options(
+        "value: h\u{e9} ${NAME}\n",
+        property_options_with_map(Some(properties)),
+    )
+    .unwrap();
+
+    assert_eq!(parsed.value, "h\u{e9} world");
+}
+
+#[test]
+fn unsupported_default_form_errors() {
+    let err = from_str_with_options::<ScalarConfig>(
+        "value: ${NAME:?required}\n",
+        property_options_with_map(Some(HashMap::new())),
+    )
+    .unwrap_err();
+
+    match err.without_snippet() {
+        serde_saphyr::Error::InvalidPropertyName { name, .. } => {
+            assert_eq!(name, "${NAME:?required}");
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn bare_dash_form_errors() {
+    let err = from_str_with_options::<ScalarConfig>(
+        "value: ${NAME-fallback}\n",
+        property_options_with_map(Some(HashMap::new())),
+    )
+    .unwrap_err();
+
+    match err.without_snippet() {
+        serde_saphyr::Error::InvalidPropertyName { name, .. } => {
+            assert_eq!(name, "${NAME-fallback}");
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn default_text_is_taken_literally() {
+    let parsed: ScalarConfig = from_str_with_options(
+        "value: ${NAME:-keep $$ as-is}\n",
+        property_options_with_map(Some(HashMap::new())),
+    )
+    .unwrap();
+
+    assert_eq!(parsed.value, "keep $$ as-is");
+}
+
+#[test]
+fn whitespace_around_name_is_rejected() {
+    let err = from_str_with_options::<ScalarConfig>(
+        "value: ${NAME :- fallback}\n",
+        property_options_with_map(Some(HashMap::new())),
+    )
+    .unwrap_err();
+
+    match err.without_snippet() {
+        serde_saphyr::Error::InvalidPropertyName { name, .. } => {
+            assert_eq!(name, "${NAME :- fallback}");
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn leading_space_in_name_is_rejected() {
+    let err = from_str_with_options::<ScalarConfig>(
+        "value: ${ NAME}\n",
+        property_options_with_map(Some(HashMap::new())),
+    )
+    .unwrap_err();
+
+    match err.without_snippet() {
+        serde_saphyr::Error::InvalidPropertyName { name, .. } => {
+            assert_eq!(name, "${ NAME}");
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn first_closing_brace_ends_default_text() {
+    let parsed: ScalarConfig = from_str_with_options(
+        "value: ${NAME:-a}b}\n",
+        property_options_with_map(Some(HashMap::new())),
+    )
+    .unwrap();
+
+    assert_eq!(parsed.value, "ab}");
+}
+
+#[test]
 fn error_snippet_keeps_property_names_and_hides_resolved_values() {
     let mut properties = HashMap::new();
     properties.insert("BAD".to_string(), "not-a-number".to_string());


### PR DESCRIPTION
I am not sure if this is a change that you would want given the marker in the README

> Interpolation is intentionally narrow in scope

I am fine with this not being a feature, but thought that this is likely a feature that is very handy for writing configuration files, so at least discussing it is likely beneficial.

Likewise, I wrote this as a PR instead of an issue because I thought it is likely easier to communicate this way.
Happy to restart from an issue if you like this more.

I tested it in an integration test since there appears to be a slight preference for this.