### PR TITLE
feat(property): Add more property-modifiers (`-`, `+`, `:+`)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -170,7 +170,7 @@ jobs:
           cargo llvm-cov --all-features --lcov --output-path lcov.info
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: bourumir-wyngs/serde-saphyr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "garde"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +769,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +791,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -827,10 +884,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -893,6 +994,7 @@ dependencies = [
  "nohash-hasher",
  "num-traits",
  "regex",
+ "rstest",
  "serde",
  "serde-transcode",
  "serde_bytes",
@@ -1006,6 +1108,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1154,6 +1262,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -1458,6 +1578,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ serde_path_to_error = "0.1"
 serde_json = { version = "1", features = ["preserve_order"] }
 miette = { version = "7", features = ["fancy"] }
 tempfile = "3.27.0"
+rstest = "0.26"
 
 [package.metadata]
 status = "actively developed"

--- a/README.md
+++ b/README.md
@@ -465,20 +465,31 @@ merge keys.
 
 ### Properties
 
-Many configuration formats contain secret values that should not be part of checked-in repository content and should not leak into error snippets or other messages. The optional `properties` feature adds docker-compose-style `${NAME}` interpolation for that use case, allowing you to provide values through [`Options`](https://docs.rs/serde-saphyr/latest/serde_saphyr/options/struct.Options.html). The feature can also be used to configure generated values, or values that change between releases or deployments, or are otherwise more convenient to specify separately from the main YAML document.
+Many configuration formats contain secret values that should not live in checked-in YAML or leak into error snippets.
+The optional `properties` feature adds docker-compose-style `${NAME}` interpolation for that use case, with values supplied through [`Options`](https://docs.rs/serde-saphyr/latest/serde_saphyr/options/struct.Options.html).
+It is also useful for generated values or values that change between releases or deployments.
 
-Interpolation is intentionally narrow in scope:
+Interpolation is intentionally narrow:
 
-- it only applies to **plain scalars**; quoted scalars and block scalars stay literal,
-- the supported forms are `${NAME}` and `${NAME:-default}`. No other docker-compose modifiers (`:-` is the only one) are supported,
+- it only applies to **plain scalars**; quoted and block scalars stay literal,
+- the supported forms are listed in the table below.
+  The error-message modifiers (`?`, `:?`) and the unbraced `$NAME` form are not currently supported,
 - `$${NAME}` escapes to a literal `${NAME}`,
-- if no property map is configured, `${NAME}` and `${NAME:-default}` remain unchanged instead of being treated specially.
+- nesting is not supported: `default`/`replacement` text is taken verbatim up to the first `}` with no further interpolation or escape processing,
+- if no property map is configured, every `${...}` form remains unchanged.
 
-For `${NAME:-default}`, the `default` text is used when `NAME` is unset or set to an empty string. It is taken verbatim up to the first `}` with no escape processing, so it cannot itself contain a `}`. Defaults are treated as ordinary literal text from the YAML source; they are not considered secret because they already appear in the YAML. 
+| Form | `NAME` unset | `NAME` set to empty | `NAME` set to non-empty |
+| --- | --- | --- | --- |
+| `${NAME}` | error | `""` | the value |
+| `${NAME-default}` | `default` | `""` | the value |
+| `${NAME:-default}` | `default` | `default` | the value |
+| `${NAME+replacement}` | `""` | `replacement` | `replacement` |
+| `${NAME:+replacement}` | `""` | `""` | `replacement` |
 
-When interpolation changes a scalar, later dynamic error messages may redact the resolved text back to the original `${...}` expression. This redaction is primarily intended to protect values pulled from the property map. That means you can opt in where it is useful without changing the meaning of YAML constructs that are typically expected to remain exact text.
+`default` and `replacement` are literal text from the YAML and are not treated as secret.
 
-`properties` is gated behind the `properties` feature flag. Once enabled, pass a property map through `Options::with_properties(...)`:
+`properties` is gated behind the `properties` feature flag.
+Once enabled, pass a property map through `Options::with_properties(...)`:
 
 ```rust
 #[cfg(feature = "properties")]
@@ -523,9 +534,12 @@ fn property_map_example_works() {
 }
 ```
 
-If interpolation is enabled but a referenced property is missing and no `${NAME:-default}` was supplied, or the `${...}` name is invalid, deserialization fails with a dedicated error that points to the YAML source location. This is useful both for correctness and for security: configuration mistakes should fail closed instead of silently producing partial or surprising values.
+A bare `${NAME}` with no value in the map (and no `-`/`:-` default), or a malformed `${...}` candidate (invalid name, unsupported modifier), fails deserialization with a dedicated error pointing at the YAML source location.
+Configuration mistakes fail closed rather than silently producing partial values.
 
-The security aspect matters most when the property values are secrets. Interpolation resolves the final value before Serde finishes deserializing the surrounding type, so downstream custom deserializers, validation code, or other error paths could otherwise end up echoing the resolved secret. `serde-saphyr` tracks interpolated values during deserialization and redacts them back to their original `${NAME}` form in later error messages, reducing the risk of leaking secrets into logs or diagnostics. You should still treat the property map itself as sensitive input and avoid formatting or logging it directly in your application.
+When the property values are secrets, interpolation resolves the final value before Serde finishes deserializing the surrounding type, so a downstream custom deserializer or validation path could otherwise echo the resolved secret.
+`serde-saphyr` tracks interpolated values and redacts them back to their `${...}` form in later error messages.
+Treat the property map itself as sensitive - do not log or format it directly.
 
 ### Includes
 

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -827,7 +827,8 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
         let view = match self.peek_scalar_view()? {
             Some(view) => {
                 // Check for null - not valid for string deserialization
-                if (view.tag == SfTag::Null || scalar_is_nullish(&view.effective, &view.style))
+                if (view.tag == SfTag::Null
+                    || (!view.interpolated && scalar_is_nullish(&view.effective, &view.style)))
                     && view.tag != SfTag::String
                 {
                     let loc = view.location;
@@ -910,7 +911,8 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
         // Reject YAML null when deserializing into String. Allow quoted forms.
         let view = if let Some(view) = self.peek_scalar_view()? {
             // If explicitly tagged as null, or plain null-like, this is not a valid String.
-            if (view.tag == SfTag::Null || scalar_is_nullish(&view.effective, &view.style))
+            if (view.tag == SfTag::Null
+                || (!view.interpolated && scalar_is_nullish(&view.effective, &view.style)))
                 && view.tag != SfTag::String
             {
                 // Consume the scalar to anchor the error at the correct location.

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -826,7 +826,8 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
     fn deserialize_str<V: Visitor<'de>>(mut self, visitor: V) -> Result<V::Value, Self::Error> {
         let view = match self.peek_scalar_view()? {
             Some(view) => {
-                // Check for null - not valid for string deserialization
+                // Check for null - not valid for string deserialization. A deliberately
+                // substituted ${...} that resolved to "" stays a string, not null.
                 if (view.tag == SfTag::Null
                     || (!view.interpolated && scalar_is_nullish(&view.effective, &view.style)))
                     && view.tag != SfTag::String
@@ -911,6 +912,7 @@ impl<'de, 'e> de::Deserializer<'de> for YamlDeserializer<'de, 'e> {
         // Reject YAML null when deserializing into String. Allow quoted forms.
         let view = if let Some(view) = self.peek_scalar_view()? {
             // If explicitly tagged as null, or plain null-like, this is not a valid String.
+            // A ${...} that the user deliberately substituted to "" is a legitimate string.
             if (view.tag == SfTag::Null
                 || (!view.interpolated && scalar_is_nullish(&view.effective, &view.style)))
                 && view.tag != SfTag::String

--- a/src/de/properties.rs
+++ b/src/de/properties.rs
@@ -40,9 +40,28 @@ fn parse_name(input: &str) -> Option<(&str, &str)> {
     Some((&input[..end], &input[end..]))
 }
 
+/// The five docker-compose `${...}` substitution forms.
+/// The `&str` payload is the default or replacement text.
+/// It may be empty.
+enum BraceOp<'a> {
+    /// `${VAR}`.
+    /// Errors when `VAR` is unset.
+    Required,
+    /// `${VAR-text}`.
+    /// An empty `VAR` still passes through.
+    DefaultIfUnset(&'a str),
+    /// `${VAR:-text}`.
+    DefaultIfUnsetOrEmpty(&'a str),
+    /// `${VAR+text}`.
+    /// An empty `VAR` counts as set.
+    AlternateIfSet(&'a str),
+    /// `${VAR:+text}`.
+    AlternateIfSetAndNonEmpty(&'a str),
+}
+
 struct BraceRef<'a> {
     name: &'a str,
-    default: Option<&'a str>,
+    op: BraceOp<'a>,
 }
 
 /// Returns `Err` when the `${...}` candidate is malformed, `Ok(None)` when the brace
@@ -62,41 +81,46 @@ fn parse_braced_reference(
         return Err(input[start..close + 1].to_owned());
     };
 
-    if rest.is_empty() {
-        return Ok(Some((
-            BraceRef {
-                name,
-                default: None,
-            },
-            close + 1,
-        )));
-    }
+    let op = if rest.is_empty() {
+        BraceOp::Required
+    } else if let Some(text) = rest.strip_prefix(":-") {
+        BraceOp::DefaultIfUnsetOrEmpty(text)
+    } else if let Some(text) = rest.strip_prefix(":+") {
+        BraceOp::AlternateIfSetAndNonEmpty(text)
+    } else if let Some(text) = rest.strip_prefix('-') {
+        BraceOp::DefaultIfUnset(text)
+    } else if let Some(text) = rest.strip_prefix('+') {
+        BraceOp::AlternateIfSet(text)
+    } else {
+        return Err(input[start..close + 1].to_owned());
+    };
 
-    let default_text = rest
-        .strip_prefix(":-")
-        .ok_or_else(|| input[start..close + 1].to_owned())?;
-    Ok(Some((
-        BraceRef {
-            name,
-            default: Some(default_text),
-        },
-        close + 1,
-    )))
+    Ok(Some((BraceRef { name, op }, close + 1)))
 }
 
 fn resolve_brace<'a>(
     brace: &'a BraceRef<'a>,
     vars: &'a HashMap<String, String>,
 ) -> Result<&'a str, &'a str> {
-    match (vars.get(brace.name).map(String::as_str), brace.default) {
-        (None | Some(""), Some(default)) => Ok(default),
-        (Some(value), _) => Ok(value),
-        (None, None) => Err(brace.name),
+    let value = vars.get(brace.name).map(String::as_str);
+    match (&brace.op, value) {
+        (BraceOp::Required, Some(v)) => Ok(v),
+        (BraceOp::Required, None) => Err(brace.name),
+        (BraceOp::DefaultIfUnset(text), None) => Ok(text),
+        (BraceOp::DefaultIfUnset(_), Some(v)) => Ok(v),
+        (BraceOp::DefaultIfUnsetOrEmpty(text), None | Some("")) => Ok(text),
+        (BraceOp::DefaultIfUnsetOrEmpty(_), Some(v)) => Ok(v),
+        (BraceOp::AlternateIfSet(text), Some(_)) => Ok(text),
+        (BraceOp::AlternateIfSet(_), None) => Ok(""),
+        (BraceOp::AlternateIfSetAndNonEmpty(_), None | Some("")) => Ok(""),
+        (BraceOp::AlternateIfSetAndNonEmpty(text), Some(_)) => Ok(text),
     }
 }
 
-/// Expands `${NAME}` and `${NAME:-default}` references in `input` against `vars`.
-/// Values in `vars` are taken as final, so placeholders inside map entries are not re-expanded.
+/// Expands docker-compose-style `${...}` references in `input` against `vars`.
+/// See [`BraceOp`] for the supported forms.
+/// Values in `vars` are taken as final.
+/// Placeholders inside map entries are not re-expanded.
 /// Returns `Cow::Borrowed` when nothing changed so the common no-`$` path stays allocation-free.
 pub(crate) fn interpolate_compose_style<'s>(
     input: Cow<'s, str>,
@@ -176,43 +200,74 @@ pub(crate) fn interpolate_compose_style<'s>(
 #[cfg(test)]
 mod tests {
     use super::{PropertyError, interpolate_compose_style};
+    use rstest::rstest;
     use std::borrow::Cow;
     use std::collections::HashMap;
 
+    fn vars() -> HashMap<String, String> {
+        HashMap::from([
+            (String::from("SET"), String::from("value")),
+            (String::from("EMPTY"), String::new()),
+        ])
+    }
+
+    #[rstest]
+    #[case::required_nonempty("${SET}", "value")]
+    #[case::required_empty("${EMPTY}", "")]
+    #[case::default_unset("${MISSING-fallback}", "fallback")]
+    #[case::default_empty("${EMPTY-fallback}", "")]
+    #[case::default_nonempty("${SET-fallback}", "value")]
+    #[case::default_if_empty_unset("${MISSING:-fallback}", "fallback")]
+    #[case::default_if_empty_empty("${EMPTY:-fallback}", "fallback")]
+    #[case::default_if_empty_nonempty("${SET:-fallback}", "value")]
+    #[case::alternate_unset("${MISSING+yes}", "")]
+    #[case::alternate_empty("${EMPTY+yes}", "yes")]
+    #[case::alternate_nonempty("${SET+yes}", "yes")]
+    #[case::alternate_if_nonempty_unset("${MISSING:+yes}", "")]
+    #[case::alternate_if_nonempty_empty("${EMPTY:+yes}", "")]
+    #[case::alternate_if_nonempty_nonempty("${SET:+yes}", "yes")]
+    fn brace_op_resolves(#[case] input: &str, #[case] expected: &str) {
+        let output = interpolate_compose_style(Cow::Borrowed(input), &vars()).unwrap();
+        assert_eq!(output.as_ref(), expected);
+    }
+
+    #[test]
+    fn required_form_errors_when_var_is_unset() {
+        let error = interpolate_compose_style(Cow::Borrowed("${MISSING}"), &vars()).unwrap_err();
+
+        assert_eq!(error, PropertyError::Unresolved("MISSING".to_string()));
+    }
+
+    #[rstest]
+    #[case("${MISSING-}")]
+    #[case("${MISSING:-}")]
+    #[case("${SET+}")]
+    #[case("${SET:+}")]
+    fn empty_default_or_replacement_text_resolves_to_empty(#[case] input: &str) {
+        let output = interpolate_compose_style(Cow::Borrowed(input), &vars()).unwrap();
+        assert_eq!(output.as_ref(), "");
+    }
+
     #[test]
     fn keeps_input_without_dollar_borrowed() {
-        let vars = HashMap::from([(String::from("NAME"), String::from("value"))]);
         let input = Cow::Borrowed("plain text");
 
-        let output = interpolate_compose_style(input, &vars).unwrap();
+        let output = interpolate_compose_style(input, &vars()).unwrap();
 
         assert_eq!(output, Cow::Borrowed("plain text"));
     }
 
     #[test]
-    fn replaces_braced_property_reference() {
-        let vars = HashMap::from([(String::from("NAME"), String::from("world"))]);
-
-        let output = interpolate_compose_style(Cow::Borrowed("hello ${NAME}"), &vars).unwrap();
-
-        assert_eq!(output.as_ref(), "hello world");
-    }
-
-    #[test]
     fn replaces_reference_after_non_ascii_text() {
-        let vars = HashMap::from([(String::from("NAME"), String::from("world"))]);
+        let output = interpolate_compose_style(Cow::Borrowed("h\u{e9} ${SET}"), &vars()).unwrap();
 
-        let output = interpolate_compose_style(Cow::Borrowed("h\u{e9} ${NAME}"), &vars).unwrap();
-
-        assert_eq!(output.as_ref(), "h\u{e9} world");
+        assert_eq!(output.as_ref(), "h\u{e9} value");
     }
 
     #[test]
     fn reports_invalid_property_name() {
-        let vars = HashMap::from([(String::from("NAME"), String::from("world"))]);
-
         let error =
-            interpolate_compose_style(Cow::Borrowed("${NAME:?fallback}"), &vars).unwrap_err();
+            interpolate_compose_style(Cow::Borrowed("${NAME:?fallback}"), &vars()).unwrap_err();
 
         assert_eq!(
             error,
@@ -221,20 +276,9 @@ mod tests {
     }
 
     #[test]
-    fn returns_unresolved_property_name() {
-        let vars = HashMap::new();
-
-        let error = interpolate_compose_style(Cow::Borrowed("${NAME}"), &vars).unwrap_err();
-
-        assert_eq!(error, PropertyError::Unresolved("NAME".to_string()));
-    }
-
-    #[test]
     fn treats_double_dollar_as_escape() {
-        let vars = HashMap::from([(String::from("NAME"), String::from("world"))]);
+        let output = interpolate_compose_style(Cow::Borrowed("$${SET}"), &vars()).unwrap();
 
-        let output = interpolate_compose_style(Cow::Borrowed("$${NAME}"), &vars).unwrap();
-
-        assert_eq!(output.as_ref(), "${NAME}");
+        assert_eq!(output.as_ref(), "${SET}");
     }
 }

--- a/tests/test_properties.rs
+++ b/tests/test_properties.rs
@@ -264,14 +264,14 @@ fn missing_property_is_an_error_when_properties_are_enabled() {
 #[test]
 fn invalid_property_name_is_an_error_when_properties_are_enabled() {
     let err = from_str_with_options::<ScalarConfig>(
-        "value: ${ab-cd}\n",
+        "value: ${1abc}\n",
         property_options_with_map(Some(HashMap::new())),
     )
     .unwrap_err();
 
     match err.without_snippet() {
         serde_saphyr::Error::InvalidPropertyName { name, location } => {
-            assert_eq!(name, "${ab-cd}");
+            assert_eq!(name, "${1abc}");
             assert_ne!(*location, serde_saphyr::Location::UNKNOWN);
         }
         other => panic!("unexpected error variant: {other:?}"),
@@ -279,10 +279,10 @@ fn invalid_property_name_is_an_error_when_properties_are_enabled() {
 
     let err_str = err.to_string();
     assert!(
-        err_str.contains("Invalid name: '${ab-cd}'"),
+        err_str.contains("Invalid name: '${1abc}'"),
         "unexpected: {err_str}"
     );
-    assert!(err_str.contains("value: ${ab-cd}"), "unexpected: {err_str}");
+    assert!(err_str.contains("value: ${1abc}"), "unexpected: {err_str}");
 }
 
 #[test]
@@ -316,19 +316,55 @@ fn unsupported_default_form_errors() {
 }
 
 #[test]
-fn bare_dash_form_errors() {
-    let err = from_str_with_options::<ScalarConfig>(
+fn bare_dash_form_uses_default_when_unset() {
+    let parsed: ScalarConfig = from_str_with_options(
         "value: ${NAME-fallback}\n",
         property_options_with_map(Some(HashMap::new())),
     )
-    .unwrap_err();
+    .unwrap();
 
-    match err.without_snippet() {
-        serde_saphyr::Error::InvalidPropertyName { name, .. } => {
-            assert_eq!(name, "${NAME-fallback}");
-        }
-        other => panic!("unexpected error variant: {other:?}"),
-    }
+    assert_eq!(parsed.value, "fallback");
+}
+
+#[test]
+fn bare_dash_form_passes_empty_value_through() {
+    let mut properties = HashMap::new();
+    properties.insert("NAME".to_string(), String::new());
+
+    let parsed: ScalarConfig = from_str_with_options(
+        "value: prefix-${NAME-fallback}-suffix\n",
+        property_options_with_map(Some(properties)),
+    )
+    .unwrap();
+
+    assert_eq!(parsed.value, "prefix--suffix");
+}
+
+#[test]
+fn alternate_form_substitutes_when_set() {
+    let mut properties = HashMap::new();
+    properties.insert("FLAG".to_string(), "anything".to_string());
+
+    let parsed: ScalarConfig = from_str_with_options(
+        "value: ${FLAG+enabled}\n",
+        property_options_with_map(Some(properties)),
+    )
+    .unwrap();
+
+    assert_eq!(parsed.value, "enabled");
+}
+
+#[test]
+fn alternate_with_colon_skips_empty_value() {
+    let mut properties = HashMap::new();
+    properties.insert("FLAG".to_string(), String::new());
+
+    let parsed: ScalarConfig = from_str_with_options(
+        "value: ${FLAG:+enabled}tail\n",
+        property_options_with_map(Some(properties)),
+    )
+    .unwrap();
+    assert_eq!(parsed.value, "tail");
 }
 
 #[test]

--- a/tests/test_properties.rs
+++ b/tests/test_properties.rs
@@ -1,6 +1,7 @@
 #![cfg(all(feature = "serialize", feature = "deserialize"))]
 #![cfg(feature = "properties")]
 
+use rstest::rstest;
 use serde::Deserialize;
 use serde_saphyr::{
     Options, from_multiple_with_options, from_reader_with_options, from_str_with_options,
@@ -365,6 +366,32 @@ fn alternate_with_colon_skips_empty_value() {
     )
     .unwrap();
     assert_eq!(parsed.value, "tail");
+}
+
+#[rstest]
+#[case::bare_reference_set_empty("${EMPTY}", &[("EMPTY", "")])]
+#[case::alternate_unset("${FLAG+enabled}", &[])]
+#[case::alternate_colon_unset("${FLAG:+enabled}", &[])]
+#[case::alternate_colon_set_empty("${FLAG:+enabled}", &[("FLAG", "")])]
+#[case::empty_default_for_unset("${MISSING-}", &[])]
+#[case::empty_colon_default_for_unset("${MISSING:-}", &[])]
+#[case::dash_passes_empty_value_through("${EMPTY-fallback}", &[("EMPTY", "")])]
+fn whole_scalar_empty_interpolation_deserializes_as_empty_string(
+    #[case] placeholder: &str,
+    #[case] entries: &[(&str, &str)],
+) {
+    let properties: HashMap<String, String> = entries
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+
+    let parsed: ScalarConfig = from_str_with_options(
+        &format!("value: {placeholder}\n"),
+        property_options_with_map(Some(properties)),
+    )
+    .unwrap();
+
+    assert_eq!(parsed.value, "");
 }
 
 #[test]


### PR DESCRIPTION
Same as the previous PR, I don't know if such a replacement is in or out of scope.

- `${VAR}`: Values that must be configured (DB URLs, API keys). An unset var is a misconfiguration, not something to paper over -> a loud error at parse time
- `${VAR-fallback}`:  Empty value is meaningful and distinct from "not configured".
  F.ex. `PREFIX=""` -> "no prefix".
- `${VAR:-fallback}`: The "regular" default, so f.ex. `${PORT:-8080}`
- `${VAR+text}`: F.ex. `${DEBUG+--verbose}` emits the flag whenever DEBUG exists in the environment, regardless of value.
- `${VAR:+text}`: Same as above, but differentiating empty <-> null

I added rstest as a dependency since for the kind of semi-repetitive tests below it is otherwise quite the mouth full to read+write, but if you prefer the previous style I am more than happy to revert.