### PR TITLE
add `${VAR?msg}` and `${VAR:?msg}` error-on-missing forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,9 +473,9 @@ Interpolation is intentionally narrow:
 
 - it only applies to **plain scalars**; quoted and block scalars stay literal,
 - the supported forms are listed in the table below.
-  The error-message modifiers (`?`, `:?`) and the unbraced `$NAME` form are not currently supported,
+  The unbraced `$NAME` form is not currently supported,
 - `$${NAME}` escapes to a literal `${NAME}`,
-- nesting is not supported: `default`/`replacement` text is taken verbatim up to the first `}` with no further interpolation or escape processing,
+- nesting is not supported: `default`/`replacement`/`error` text is taken verbatim up to the first `}` with no further interpolation or escape processing,
 - if no property map is configured, every `${...}` form remains unchanged.
 
 | Form | `NAME` unset | `NAME` set to empty | `NAME` set to non-empty |
@@ -485,9 +485,11 @@ Interpolation is intentionally narrow:
 | `${NAME:-default}` | `default` | `default` | the value |
 | `${NAME+replacement}` | `""` | `replacement` | `replacement` |
 | `${NAME:+replacement}` | `""` | `""` | `replacement` |
+| `${NAME?error}` | error (with `error` as hint) | `""` | the value |
+| `${NAME:?error}` | error (with `error` as hint) | error (with `error` as hint) | the value |
 
-`default` and `replacement` are literal text from the YAML and are not treated as secret. If the target is `Option`,
-nullish values (null, empty and ~) are deserialized into `None`.
+`default`, `replacement`, and `error` are literal text from the YAML and are not treated as secret.
+The `error` hint may be empty (`${NAME?}` / `${NAME:?}`), matching docker-compose.
 
 `properties` is gated behind the `properties` feature flag.
 Once enabled, pass a property map through `Options::with_properties(...)`:
@@ -535,7 +537,7 @@ fn property_map_example_works() {
 }
 ```
 
-A bare `${NAME}` with no value in the map (and no `-`/`:-` default), or a malformed `${...}` candidate (invalid name, unsupported modifier), fails deserialization with a dedicated error pointing at the YAML source location.
+A bare `${NAME}` with no value in the map (and no `-`/`:-` default), a `${NAME?msg}` / `${NAME:?msg}` that triggers its error condition, or a malformed `${...}` candidate (invalid name, unsupported modifier), fails deserialization with a dedicated error pointing at the YAML source location.
 Configuration mistakes fail closed rather than silently producing partial values.
 
 When the property values are secrets, interpolation resolves the final value before Serde finishes deserializing the surrounding type, so a downstream custom deserializer or validation path could otherwise echo the resolved secret.

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -479,6 +479,20 @@ impl<'de, 'e> YamlDeserializer<'de, 'e> {
                 Err(crate::properties::PropertyError::InvalidName(name)) => {
                     Err(Error::InvalidPropertyName { name, location })
                 }
+                Err(crate::properties::PropertyError::RequiredButUnset { name, message }) => {
+                    Err(Error::PropertyRequiredButUnset {
+                        name,
+                        message,
+                        location,
+                    })
+                }
+                Err(crate::properties::PropertyError::RequiredButEmpty { name, message }) => {
+                    Err(Error::PropertyRequiredButEmpty {
+                        name,
+                        message,
+                        location,
+                    })
+                }
             }
         }
     }

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -746,6 +746,20 @@ pub enum Error {
         name: String,
         location: Location,
     },
+    /// A `${NAME?text}` or `${NAME:?text}` reference required a value but the property was unset.
+    /// `message` may be empty.
+    PropertyRequiredButUnset {
+        name: String,
+        message: String,
+        location: Location,
+    },
+    /// A `${NAME:?text}` reference required a non-empty value but the property was present and empty.
+    /// `message` may be empty.
+    PropertyRequiredButEmpty {
+        name: String,
+        message: String,
+        location: Location,
+    },
     /// A YAML budget limit was exceeded.
     Budget {
         breach: BudgetBreach,
@@ -1411,6 +1425,8 @@ impl Error {
             | Error::HookError { location, .. }
             | Error::UnresolvedProperty { location, .. }
             | Error::InvalidPropertyName { location, .. }
+            | Error::PropertyRequiredButUnset { location, .. }
+            | Error::PropertyRequiredButEmpty { location, .. }
             | Error::ContainerEndMismatch { location, .. }
             | Error::UnknownAnchor { location, .. }
             | Error::CyclicInclude { location, .. }
@@ -1507,6 +1523,8 @@ impl Error {
             | Error::HookError { location, .. }
             | Error::UnresolvedProperty { location, .. }
             | Error::InvalidPropertyName { location, .. }
+            | Error::PropertyRequiredButUnset { location, .. }
+            | Error::PropertyRequiredButEmpty { location, .. }
             | Error::ContainerEndMismatch { location, .. }
             | Error::UnknownAnchor { location, .. }
             | Error::CyclicInclude { location, .. }
@@ -1618,6 +1636,8 @@ impl Error {
             | Error::HookError { location, .. }
             | Error::UnresolvedProperty { location, .. }
             | Error::InvalidPropertyName { location, .. }
+            | Error::PropertyRequiredButUnset { location, .. }
+            | Error::PropertyRequiredButEmpty { location, .. }
             | Error::ContainerEndMismatch { location, .. }
             | Error::UnknownAnchor { location, .. }
             | Error::CyclicInclude { location, .. }

--- a/src/de/message_formatters.rs
+++ b/src/de/message_formatters.rs
@@ -44,6 +44,18 @@ fn default_format_message<'a>(formatter: &dyn MessageFormatter, err: &'a Error) 
         | Error::SerdeVariantId { msg, .. } => Cow::Borrowed(msg.as_str()),
         Error::UnresolvedProperty { name, .. } => Cow::Owned(format!("missing property `{name}`")),
         Error::InvalidPropertyName { name, .. } => Cow::Owned(format!("Invalid name: '{name}'")),
+        Error::PropertyRequiredButUnset { name, message, .. } if message.is_empty() => {
+            Cow::Owned(format!("missing property `{name}`"))
+        }
+        Error::PropertyRequiredButUnset { name, message, .. } => {
+            Cow::Owned(format!("missing property `{name}`: {message}"))
+        }
+        Error::PropertyRequiredButEmpty { name, message, .. } if message.is_empty() => {
+            Cow::Owned(format!("empty property `{name}`"))
+        }
+        Error::PropertyRequiredButEmpty { name, message, .. } => {
+            Cow::Owned(format!("empty property `{name}`: {message}"))
+        }
         Error::Eof { .. } => Cow::Borrowed("unexpected end of input"),
         Error::MultipleDocuments { hint, .. } => {
             Cow::Owned(format!("multiple YAML documents detected; {hint}"))
@@ -806,6 +818,44 @@ mod tests {
             location: loc(),
         };
         assert_eq!(formatter.format_message(&err), "Invalid name: '${ab-cd}'");
+    }
+
+    #[rstest::rstest]
+    #[case::unset_with_message(
+        Error::PropertyRequiredButUnset {
+            name: "DB_HOST".to_owned(),
+            message: "set DB_HOST in .env".to_owned(),
+            location: loc(),
+        },
+        "missing property `DB_HOST`: set DB_HOST in .env",
+    )]
+    #[case::unset_empty_message(
+        Error::PropertyRequiredButUnset {
+            name: "DB_HOST".to_owned(),
+            message: String::new(),
+            location: loc(),
+        },
+        "missing property `DB_HOST`",
+    )]
+    #[case::empty_with_message(
+        Error::PropertyRequiredButEmpty {
+            name: "DB_HOST".to_owned(),
+            message: "must not be blank".to_owned(),
+            location: loc(),
+        },
+        "empty property `DB_HOST`: must not be blank",
+    )]
+    #[case::empty_empty_message(
+        Error::PropertyRequiredButEmpty {
+            name: "DB_HOST".to_owned(),
+            message: String::new(),
+            location: loc(),
+        },
+        "empty property `DB_HOST`",
+    )]
+    fn default_property_required_messages(#[case] err: Error, #[case] expected: &str) {
+        let formatter = DefaultMessageFormatter;
+        assert_eq!(formatter.format_message(&err), expected);
     }
 
     #[test]

--- a/src/de/properties.rs
+++ b/src/de/properties.rs
@@ -5,9 +5,15 @@ use std::collections::HashMap;
 pub(crate) enum PropertyError {
     /// `${NAME}` had no value in the property map and no default was supplied.
     Unresolved(String),
-    /// A `${...}` candidate was present but did not parse as a supported braced
-    /// property form. The string is the full candidate including braces.
+    /// A `${...}` candidate was present but did not parse as a supported form.
+    /// The string is the full candidate including braces.
     InvalidName(String),
+    /// `${NAME?text}` or `${NAME:?text}` referenced a variable that was unset.
+    /// `message` may be empty.
+    RequiredButUnset { name: String, message: String },
+    /// `${NAME:?text}` referenced a variable that was present but empty.
+    /// `message` may be empty.
+    RequiredButEmpty { name: String, message: String },
 }
 
 /// Checks whether a character is valid as the first character of a variable name.
@@ -40,8 +46,8 @@ fn parse_name(input: &str) -> Option<(&str, &str)> {
     Some((&input[..end], &input[end..]))
 }
 
-/// The five docker-compose `${...}` substitution forms.
-/// The `&str` payload is the default or replacement text.
+/// The docker-compose `${...}` substitution forms.
+/// The `&str` payload is the default, replacement, or error text.
 /// It may be empty.
 enum BraceOp<'a> {
     /// `${VAR}`.
@@ -57,6 +63,12 @@ enum BraceOp<'a> {
     AlternateIfSet(&'a str),
     /// `${VAR:+text}`.
     AlternateIfSetAndNonEmpty(&'a str),
+    /// `${VAR?text}`.
+    /// Errors when `VAR` is unset; an empty `VAR` still passes through.
+    ErrorIfUnset(&'a str),
+    /// `${VAR:?text}`.
+    /// Errors when `VAR` is unset or empty.
+    ErrorIfUnsetOrEmpty(&'a str),
 }
 
 struct BraceRef<'a> {
@@ -91,6 +103,10 @@ fn parse_braced_reference(
         BraceOp::DefaultIfUnset(text)
     } else if let Some(text) = rest.strip_prefix('+') {
         BraceOp::AlternateIfSet(text)
+    } else if let Some(text) = rest.strip_prefix(":?") {
+        BraceOp::ErrorIfUnsetOrEmpty(text)
+    } else if let Some(text) = rest.strip_prefix('?') {
+        BraceOp::ErrorIfUnset(text)
     } else {
         return Err(input[start..close + 1].to_owned());
     };
@@ -101,11 +117,12 @@ fn parse_braced_reference(
 fn resolve_brace<'a>(
     brace: &'a BraceRef<'a>,
     vars: &'a HashMap<String, String>,
-) -> Result<&'a str, &'a str> {
-    let value = vars.get(brace.name).map(String::as_str);
+) -> Result<&'a str, PropertyError> {
+    let name = brace.name;
+    let value = vars.get(name).map(String::as_str);
     match (&brace.op, value) {
         (BraceOp::Required, Some(v)) => Ok(v),
-        (BraceOp::Required, None) => Err(brace.name),
+        (BraceOp::Required, None) => Err(PropertyError::Unresolved(name.to_owned())),
         (BraceOp::DefaultIfUnset(text), None) => Ok(text),
         (BraceOp::DefaultIfUnset(_), Some(v)) => Ok(v),
         (BraceOp::DefaultIfUnsetOrEmpty(text), None | Some("")) => Ok(text),
@@ -114,6 +131,20 @@ fn resolve_brace<'a>(
         (BraceOp::AlternateIfSet(_), None) => Ok(""),
         (BraceOp::AlternateIfSetAndNonEmpty(_), None | Some("")) => Ok(""),
         (BraceOp::AlternateIfSetAndNonEmpty(text), Some(_)) => Ok(text),
+        (BraceOp::ErrorIfUnset(_), Some(v)) => Ok(v),
+        (BraceOp::ErrorIfUnset(msg), None) => Err(PropertyError::RequiredButUnset {
+            name: name.to_owned(),
+            message: (*msg).to_owned(),
+        }),
+        (BraceOp::ErrorIfUnsetOrEmpty(_), Some(v)) if !v.is_empty() => Ok(v),
+        (BraceOp::ErrorIfUnsetOrEmpty(msg), Some(_)) => Err(PropertyError::RequiredButEmpty {
+            name: name.to_owned(),
+            message: (*msg).to_owned(),
+        }),
+        (BraceOp::ErrorIfUnsetOrEmpty(msg), None) => Err(PropertyError::RequiredButUnset {
+            name: name.to_owned(),
+            message: (*msg).to_owned(),
+        }),
     }
 }
 
@@ -174,8 +205,7 @@ pub(crate) fn interpolate_compose_style<'s>(
             continue;
         };
 
-        let value =
-            resolve_brace(&brace, vars).map_err(|n| PropertyError::Unresolved(n.to_owned()))?;
+        let value = resolve_brace(&brace, vars)?;
 
         if !changed {
             out.push_str(&input_str[..i]);
@@ -212,30 +242,26 @@ mod tests {
     }
 
     #[rstest]
-    #[case::required_nonempty("${SET}", "value")]
+    #[case::required_set("${SET}", "value")]
     #[case::required_empty("${EMPTY}", "")]
-    #[case::default_unset("${MISSING-fallback}", "fallback")]
-    #[case::default_empty("${EMPTY-fallback}", "")]
-    #[case::default_nonempty("${SET-fallback}", "value")]
-    #[case::default_if_empty_unset("${MISSING:-fallback}", "fallback")]
-    #[case::default_if_empty_empty("${EMPTY:-fallback}", "fallback")]
-    #[case::default_if_empty_nonempty("${SET:-fallback}", "value")]
-    #[case::alternate_unset("${MISSING+yes}", "")]
-    #[case::alternate_empty("${EMPTY+yes}", "yes")]
-    #[case::alternate_nonempty("${SET+yes}", "yes")]
-    #[case::alternate_if_nonempty_unset("${MISSING:+yes}", "")]
-    #[case::alternate_if_nonempty_empty("${EMPTY:+yes}", "")]
-    #[case::alternate_if_nonempty_nonempty("${SET:+yes}", "yes")]
+    #[case::default_if_unset_set("${SET-fallback}", "value")]
+    #[case::default_if_unset_empty("${EMPTY-fallback}", "")]
+    #[case::default_if_unset_missing("${MISSING-fallback}", "fallback")]
+    #[case::default_if_unset_or_empty_set("${SET:-fallback}", "value")]
+    #[case::default_if_unset_or_empty_empty("${EMPTY:-fallback}", "fallback")]
+    #[case::default_if_unset_or_empty_missing("${MISSING:-fallback}", "fallback")]
+    #[case::alternate_if_set_set("${SET+yes}", "yes")]
+    #[case::alternate_if_set_empty("${EMPTY+yes}", "yes")]
+    #[case::alternate_if_set_missing("${MISSING+yes}", "")]
+    #[case::alternate_if_set_and_nonempty_set("${SET:+yes}", "yes")]
+    #[case::alternate_if_set_and_nonempty_empty("${EMPTY:+yes}", "")]
+    #[case::alternate_if_set_and_nonempty_missing("${MISSING:+yes}", "")]
+    #[case::error_if_unset_set("${SET?msg}", "value")]
+    #[case::error_if_unset_empty("${EMPTY?msg}", "")]
+    #[case::error_if_unset_or_empty_set("${SET:?msg}", "value")]
     fn brace_op_resolves(#[case] input: &str, #[case] expected: &str) {
         let output = interpolate_compose_style(Cow::Borrowed(input), &vars()).unwrap();
         assert_eq!(output.as_ref(), expected);
-    }
-
-    #[test]
-    fn required_form_errors_when_var_is_unset() {
-        let error = interpolate_compose_style(Cow::Borrowed("${MISSING}"), &vars()).unwrap_err();
-
-        assert_eq!(error, PropertyError::Unresolved("MISSING".to_string()));
     }
 
     #[rstest]
@@ -267,12 +293,43 @@ mod tests {
     #[test]
     fn reports_invalid_property_name() {
         let error =
-            interpolate_compose_style(Cow::Borrowed("${NAME:?fallback}"), &vars()).unwrap_err();
+            interpolate_compose_style(Cow::Borrowed("${NAME:=fallback}"), &vars()).unwrap_err();
 
         assert_eq!(
             error,
-            PropertyError::InvalidName("${NAME:?fallback}".to_string())
+            PropertyError::InvalidName("${NAME:=fallback}".to_string())
         );
+    }
+
+    #[rstest]
+    #[case::required_missing("${MISSING}", PropertyError::Unresolved("MISSING".into()))]
+    #[case::error_if_unset_missing(
+        "${MISSING?nope}",
+        PropertyError::RequiredButUnset { name: "MISSING".into(), message: "nope".into() }
+    )]
+    #[case::error_if_unset_missing_empty_msg(
+        "${MISSING?}",
+        PropertyError::RequiredButUnset { name: "MISSING".into(), message: "".into() }
+    )]
+    #[case::error_if_unset_or_empty_missing(
+        "${MISSING:?nope}",
+        PropertyError::RequiredButUnset { name: "MISSING".into(), message: "nope".into() }
+    )]
+    #[case::error_if_unset_or_empty_missing_empty_msg(
+        "${MISSING:?}",
+        PropertyError::RequiredButUnset { name: "MISSING".into(), message: "".into() }
+    )]
+    #[case::error_if_unset_or_empty_empty(
+        "${EMPTY:?nope}",
+        PropertyError::RequiredButEmpty { name: "EMPTY".into(), message: "nope".into() }
+    )]
+    #[case::error_if_unset_or_empty_empty_empty_msg(
+        "${EMPTY:?}",
+        PropertyError::RequiredButEmpty { name: "EMPTY".into(), message: "".into() }
+    )]
+    fn brace_op_errors(#[case] input: &str, #[case] expected: PropertyError) {
+        let error = interpolate_compose_style(Cow::Borrowed(input), &vars()).unwrap_err();
+        assert_eq!(error, expected);
     }
 
     #[test]

--- a/tests/test_properties.rs
+++ b/tests/test_properties.rs
@@ -303,14 +303,14 @@ fn interpolation_works_after_non_ascii_text() {
 #[test]
 fn unsupported_default_form_errors() {
     let err = from_str_with_options::<ScalarConfig>(
-        "value: ${NAME:?required}\n",
+        "value: ${NAME:=required}\n",
         property_options_with_map(Some(HashMap::new())),
     )
     .unwrap_err();
 
     match err.without_snippet() {
         serde_saphyr::Error::InvalidPropertyName { name, .. } => {
-            assert_eq!(name, "${NAME:?required}");
+            assert_eq!(name, "${NAME:=required}");
         }
         other => panic!("unexpected error variant: {other:?}"),
     }
@@ -610,16 +610,22 @@ fn scalar_enum_variant_error_redacts_interpolated_value() {
     assert!(msg.contains("${MODE}"), "raw placeholder missing: {msg}");
 }
 
-#[test]
-fn with_snippet_output_redacts_resolved_token_values() {
+#[rstest]
+#[case::bare("${TOKEN}")]
+#[case::default_if_unset("${TOKEN-fallback}")]
+#[case::default_if_unset_or_empty("${TOKEN:-fallback}")]
+#[case::error_if_unset("${TOKEN?must be set}")]
+#[case::error_if_unset_or_empty("${TOKEN:?must be set}")]
+#[case::alternate_if_set("${TOKEN+fallback-replacement}")]
+#[case::alternate_if_set_and_nonempty("${TOKEN:+fallback-replacement}")]
+fn with_snippet_output_redacts_resolved_token_values(#[case] placeholder: &str) {
     let mut properties = HashMap::new();
     properties.insert("TOKEN".to_string(), "super-secret-token".to_string());
 
-    let err = from_str_with_options::<NumericConfig>(
-        "value: ${TOKEN}\nnearby: ${TOKEN}\n",
-        property_options_with_map(Some(properties)),
-    )
-    .unwrap_err();
+    let yaml = format!("value: {placeholder}\nnearby: {placeholder}\n");
+    let err =
+        from_str_with_options::<NumericConfig>(&yaml, property_options_with_map(Some(properties)))
+            .unwrap_err();
 
     assert!(
         matches!(err, serde_saphyr::Error::WithSnippet { .. }),
@@ -627,7 +633,7 @@ fn with_snippet_output_redacts_resolved_token_values() {
     );
 
     let msg = err.to_string();
-    assert_redacted_message(&msg, "${TOKEN}", "super-secret-token");
+    assert_redacted_message(&msg, placeholder, "super-secret-token");
 }
 
 #[test]


### PR DESCRIPTION
This PR implements the error-message variants `?` for properties.
It is usefull if you have a default config file and want to give for example an docs link, or whatever to an operator.

Also contains a few (minor) unrelated testcase cleanups (rstest, where rstest is better), but I can pull the ten-ish lines to another PR if you prefer, no problem.
Besides, added a testcase for redaction because I did not cover that before, apparently.