### PR TITLE
fix: tuple structs not serialising at the correct indentation

### DIFF
--- a/src/ser/compound.rs
+++ b/src/ser/compound.rs
@@ -341,29 +341,19 @@ impl<'a, 'b, W: Write> SpecialTupleSer<'a, 'b, W> {
     }
 }
 
-// Tuple variant (enum Variant: ( ... ))
-/// Serializer for tuple variants (enum Variant: ( ... )).
-///
-/// Created by `YamlSerializer::serialize_tuple_variant` to emit the variant name
-/// followed by a block sequence of fields.
-pub struct TupleVariantSer<'a, 'b, W: Write> {
-    /// Parent YAML serializer.
-    pub(super) ser: &'a mut YamlSerializer<'b, W>,
-    /// Target indentation depth for the fields.
-    pub(super) depth: usize,
-}
-impl<'a, 'b, W: Write> SerializeTupleVariant for TupleVariantSer<'a, 'b, W> {
+// Tuple variant (enum Variant: ( ... )).
+// `serialize_tuple_variant` writes the variant name and colon, then hands the
+// fields to a `SeqSer`: the body is just a block sequence, so it reuses the same
+// dash/indentation logic as `serialize_seq`.
+impl<'a, 'b, W: Write> SerializeTupleVariant for SeqSer<'a, 'b, W> {
     type Ok = ();
     type Error = Error;
 
     fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
-        self.ser.write_indent(self.depth)?;
-        self.ser.out.write_str("- ")?;
-        self.ser.at_line_start = false;
-        value.serialize(&mut *self.ser)
+        SerializeSeq::serialize_element(self, value)
     }
     fn end(self) -> Result<()> {
-        Ok(())
+        SerializeSeq::end(self)
     }
 }
 

--- a/src/ser/compound.rs
+++ b/src/ser/compound.rs
@@ -125,14 +125,22 @@ impl<'a, 'b, W: Write> SerializeSeq for SeqSer<'a, 'b, W> {
     }
 }
 
-// Tuple-struct serializer (normal or anchor payload)
 /// Serializer for tuple-structs.
 ///
 /// Used for three shapes:
 /// - Normal tuple-structs (treated like sequences in block style),
-/// - Internal strong-anchor payloads (`__yaml_anchor`),
-/// - Internal weak-anchor payloads (`__yaml_weak_anchor`).
-pub struct TupleSer<'a, 'b, W: Write> {
+/// - Anchors:
+///   - Internal strong-anchor payloads (`__yaml_anchor`),
+///   - Internal weak-anchor payloads (`__yaml_weak_anchor`).
+pub enum TupleSer<'a, 'b, W: Write> {
+    /// Normal tuple-struct: a block sequence.
+    Seq(SeqSer<'a, 'b, W>),
+    /// Anchor/comment wrapper payload.
+    Special(SpecialTupleSer<'a, 'b, W>),
+}
+
+/// State machine for the internal anchor/comment tuple wrappers.
+pub struct SpecialTupleSer<'a, 'b, W: Write> {
     /// Parent YAML serializer.
     ser: &'a mut YamlSerializer<'b, W>,
     /// Variant describing how to interpret fields.
@@ -156,60 +164,30 @@ pub struct TupleSer<'a, 'b, W: Write> {
     comment_text: Option<String>,
 }
 enum TupleKind {
-    Normal,       // treat as block seq
     AnchorStrong, // [ptr, value]
     AnchorWeak,   // [ptr, present, value]
     Commented,    // [comment, value]
 }
 impl<'a, 'b, W: Write> TupleSer<'a, 'b, W> {
-    /// Create a tuple serializer for normal tuple-structs.
-    pub(super) fn normal(ser: &'a mut YamlSerializer<'b, W>) -> Self {
-        let depth_next = ser.depth + 1;
-        Self {
-            ser,
-            kind: TupleKind::Normal,
-            idx: 0,
-            depth_for_normal: depth_next,
-            strong_alias_id: None,
-            weak_present: false,
-            skip_third: false,
-            weak_alias_id: None,
-            comment_text: None,
-        }
-    }
     /// Create a tuple serializer for internal strong-anchor payloads.
     pub(super) fn anchor_strong(ser: &'a mut YamlSerializer<'b, W>) -> Self {
-        Self {
-            ser,
-            kind: TupleKind::AnchorStrong,
-            idx: 0,
-            depth_for_normal: 0,
-            strong_alias_id: None,
-            weak_present: false,
-            skip_third: false,
-            weak_alias_id: None,
-            comment_text: None,
-        }
+        TupleSer::Special(SpecialTupleSer::new(ser, TupleKind::AnchorStrong))
     }
     /// Create a tuple serializer for internal weak-anchor payloads.
     pub(super) fn anchor_weak(ser: &'a mut YamlSerializer<'b, W>) -> Self {
-        Self {
-            ser,
-            kind: TupleKind::AnchorWeak,
-            idx: 0,
-            depth_for_normal: 0,
-            strong_alias_id: None,
-            weak_present: false,
-            skip_third: false,
-            weak_alias_id: None,
-            comment_text: None,
-        }
+        TupleSer::Special(SpecialTupleSer::new(ser, TupleKind::AnchorWeak))
     }
     /// Create a tuple serializer for internal commented wrapper.
     pub(super) fn commented(ser: &'a mut YamlSerializer<'b, W>) -> Self {
+        TupleSer::Special(SpecialTupleSer::new(ser, TupleKind::Commented))
+    }
+}
+
+impl<'a, 'b, W: Write> SpecialTupleSer<'a, 'b, W> {
+    fn new(ser: &'a mut YamlSerializer<'b, W>, kind: TupleKind) -> Self {
         Self {
             ser,
-            kind: TupleKind::Commented,
+            kind,
             idx: 0,
             depth_for_normal: 0,
             strong_alias_id: None,
@@ -226,19 +204,23 @@ impl<'a, 'b, W: Write> SerializeTupleStruct for TupleSer<'a, 'b, W> {
     type Error = Error;
 
     fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
+        match self {
+            TupleSer::Seq(seq) => SerializeSeq::serialize_element(seq, value),
+            TupleSer::Special(s) => s.serialize_field(value),
+        }
+    }
+
+    fn end(self) -> Result<()> {
+        match self {
+            TupleSer::Seq(seq) => SerializeSeq::end(seq),
+            TupleSer::Special(s) => s.end(),
+        }
+    }
+}
+
+impl<'a, 'b, W: Write> SpecialTupleSer<'a, 'b, W> {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
         match self.kind {
-            TupleKind::Normal => {
-                if self.idx == 0 {
-                    self.ser.write_anchor_for_complex_node()?;
-                    if !self.ser.at_line_start {
-                        self.ser.newline()?;
-                    }
-                }
-                self.ser.write_indent(self.ser.depth + 1)?;
-                self.ser.out.write_str("- ")?;
-                self.ser.at_line_start = false;
-                value.serialize(&mut *self.ser)?;
-            }
             TupleKind::AnchorStrong => {
                 match self.idx {
                     0 => {

--- a/src/ser/compound.rs
+++ b/src/ser/compound.rs
@@ -81,6 +81,8 @@ impl<'a, 'b, W: Write> SerializeSeq for SeqSer<'a, 'b, W> {
             self.ser.after_dash_depth = Some(self.depth);
             // Hint to emit first key/element of a following mapping/sequence inline on the same line.
             self.ser.pending_inline_map = true;
+            // A sibling element's block-collection state must not leak into this element.
+            self.ser.last_value_was_block = false;
             v.serialize(&mut *self.ser)?;
         }
         self.first = false;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -43,7 +43,7 @@ mod zmij_format;
 
 pub use self::error::Error;
 pub use self::serializer::{
-    MapSer, SeqSer, StructVariantSer, TupleSer, TupleVariantSer, YamlSerializer,
+    MapSer, SeqSer, StructVariantSer, TupleSer, YamlSerializer,
 };
 
 /// Result alias.

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -3,7 +3,7 @@ mod compound;
 #[path = "helpers.rs"]
 mod helpers;
 
-pub use self::compound::{MapSer, SeqSer, StructVariantSer, TupleSer, TupleVariantSer};
+pub use self::compound::{MapSer, SeqSer, StructVariantSer, TupleSer};
 
 use self::helpers::StrCapture;
 use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
@@ -577,7 +577,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
     type SerializeSeq = SeqSer<'a, 'b, W>;
     type SerializeTuple = SeqSer<'a, 'b, W>;
     type SerializeTupleStruct = TupleSer<'a, 'b, W>;
-    type SerializeTupleVariant = TupleVariantSer<'a, 'b, W>;
+    type SerializeTupleVariant = SeqSer<'a, 'b, W>;
     type SerializeMap = MapSer<'a, 'b, W>;
     type SerializeStruct = MapSer<'a, 'b, W>;
     type SerializeStructVariant = StructVariantSer<'a, 'b, W>;
@@ -1244,9 +1244,11 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
             self.out.write_str(":\n")?;
             self.at_line_start = true;
             let depth_next = base + 1;
-            return Ok(TupleVariantSer {
+            return Ok(SeqSer {
                 ser: self,
                 depth: depth_next,
+                flow: false,
+                first: true,
             });
         }
         // Otherwise (top-level or sequence context).
@@ -1261,9 +1263,11 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
             depth_next = d + 2;
             self.pending_inline_map = false;
         }
-        Ok(TupleVariantSer {
+        Ok(SeqSer {
             ser: self,
             depth: depth_next,
+            flow: false,
+            first: true,
         })
     }
 

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -1152,7 +1152,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
                 && self.after_dash_depth.is_some()
                 && !self.pending_space_after_colon;
             // `inline_first` assumes we stay mid-line, but a pending anchor writes `&aN\n` first.
-            let anchor_broke_line = false;
+            let anchor_broke_line = self.pending_anchor_id.is_some();
             self.write_anchor_for_complex_node()?;
             if inline_first {
                 if anchor_broke_line {

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -1151,13 +1151,17 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
             let inline_first = (!self.at_line_start)
                 && self.after_dash_depth.is_some()
                 && !self.pending_space_after_colon;
-            // If we are a mapping value (space after colon was pending), we will handle
-            // the newline later in SeqSer::serialize_element to keep empty sequences inline.
+            // `inline_first` assumes we stay mid-line, but a pending anchor writes `&aN\n` first.
+            let anchor_broke_line = false;
             self.write_anchor_for_complex_node()?;
             if inline_first {
-                // Keep staged inline (pending_inline_map) so the child can inline its first dash.
-                // Ensure we stay mid-line so the child can emit its first dash inline.
-                self.at_line_start = false;
+                if anchor_broke_line {
+                    // Inlining now would drop the nested dashes to column 0, past the anchor.
+                    self.pending_inline_map = false;
+                } else {
+                    // Collapsing onto the parent dash yields the preferred `- - 1` shape.
+                    self.at_line_start = false;
+                }
             } else if was_inline_value {
                 // Mid-line start. If we are here due to a map value (after ':'), defer the newline
                 // decision until the first element is emitted so that empty sequences can stay inline

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -1207,7 +1207,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
     fn serialize_tuple_struct(
         self,
         name: &'static str,
-        _len: usize,
+        len: usize,
     ) -> Result<Self::SerializeTupleStruct> {
         if name == NAME_TUPLE_ANCHOR {
             Ok(TupleSer::anchor_strong(self))
@@ -1216,8 +1216,8 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
         } else if name == NAME_TUPLE_COMMENTED {
             Ok(TupleSer::commented(self))
         } else {
-            // Treat as normal block sequence
-            Ok(TupleSer::normal(self))
+            // Normal tuple-struct: emit as a block sequence.
+            Ok(TupleSer::Seq(self.serialize_seq(Some(len))?))
         }
     }
 

--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -94,6 +94,36 @@ seq:
     }
 
     #[test]
+    fn block_seq_anchor_payload_in_sequence_indents_under_dash() {
+        #[derive(Serialize)]
+        struct Tup(u8, u8);
+
+        let shared = Rc::new(Tup(1, 2));
+        let tup_data: Vec<RcAnchor<Tup>> = vec![RcAnchor(shared.clone()), RcAnchor(shared)];
+
+        let expected = indoc! {r#"
+            - &a1
+              - 1
+              - 2
+            - *a1
+        "#};
+
+        let tup_yaml = to_string(&tup_data).expect("serialize tuple-struct anchor sequence");
+        assert_eq!(
+            tup_yaml, expected,
+            "tuple-struct payload. Got:\n{}",
+            tup_yaml
+        );
+
+        let shared_vec = Rc::new(vec![1u8, 2]);
+        let vec_data: Vec<RcAnchor<Vec<u8>>> =
+            vec![RcAnchor(shared_vec.clone()), RcAnchor(shared_vec)];
+
+        let vec_yaml = to_string(&vec_data).expect("serialize Vec anchor sequence");
+        assert_eq!(vec_yaml, expected, "Vec payload. Got:\n{}", vec_yaml);
+    }
+
+    #[test]
     fn rc_weak_anchor_present_and_dangling() {
         // Present (upgraded) weak -> emits anchored value
         let strong = Rc::new(Node {

--- a/tests/compact_list_indent.rs
+++ b/tests/compact_list_indent.rs
@@ -90,7 +90,6 @@ fn compact_list_indent_enabled() {
     assert_eq!(lines[3], "    value: WATCH");
 }
 
-/// A tuple-struct serializes via `serialize_tuple_struct`, a Vec via `serialize_seq`.
 #[test]
 fn tuple_struct_serializes_like_a_vec() {
     use std::collections::BTreeMap;

--- a/tests/compact_list_indent.rs
+++ b/tests/compact_list_indent.rs
@@ -89,3 +89,27 @@ fn compact_list_indent_enabled() {
     assert_eq!(lines[2], "  - name: METHOD");
     assert_eq!(lines[3], "    value: WATCH");
 }
+
+/// A tuple-struct serializes via `serialize_tuple_struct`, a Vec via `serialize_seq`.
+#[test]
+fn tuple_struct_serializes_like_a_vec() {
+    use std::collections::BTreeMap;
+
+    #[derive(Serialize)]
+    struct Tup(u8, u8, u8, u8);
+
+    let tup = Tup(9, 19, 11, 21);
+    let vec = vec![9u8, 19, 11, 21];
+
+    assert_eq!(
+        serde_saphyr::to_string(&tup).unwrap(),
+        serde_saphyr::to_string(&vec).unwrap(),
+    );
+
+    let as_tup = BTreeMap::from([("hello", BTreeMap::from([("world", &tup)]))]);
+    let as_vec = BTreeMap::from([("hello", BTreeMap::from([("world", &vec)]))]);
+    assert_eq!(
+        serde_saphyr::to_string(&as_tup).unwrap(),
+        serde_saphyr::to_string(&as_vec).unwrap(),
+    );
+}

--- a/tests/en_structs.rs
+++ b/tests/en_structs.rs
@@ -106,6 +106,29 @@ fn tuple_variant_round_trips_with_complex_fields(
     Ok(())
 }
 
+#[rstest]
+#[case::after_block_seq(ComplexFieldEnum::Seq(vec![
+    ComplexFieldEnum::Unit,
+    ComplexFieldEnum::Unit,
+]))]
+#[case::after_nested_tuple(ComplexFieldEnum::Tup(
+    Box::new(ComplexFieldEnum::Unit),
+    Box::new(ComplexFieldEnum::Unit),
+))]
+fn empty_tuple_field_after_block_sibling_round_trips(
+    #[case] block_first_field: ComplexFieldEnum,
+) -> anyhow::Result<()> {
+    let value = ComplexFieldEnum::Tup(
+        Box::new(block_first_field),
+        Box::new(ComplexFieldEnum::Seq(vec![])),
+    );
+    let yaml = serde_saphyr::to_string(&value)?;
+    let r: ComplexFieldEnum = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(value, r, "round-trip mismatch for:\n{yaml}");
+
+    Ok(())
+}
+
 #[test]
 fn struct_variant_round_trips_when_nested_under_a_key() -> anyhow::Result<()> {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]

--- a/tests/en_structs.rs
+++ b/tests/en_structs.rs
@@ -1,5 +1,6 @@
 #![cfg(all(feature = "serialize", feature = "deserialize"))]
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[test]
 fn test_enum_struct_1() -> anyhow::Result<()> {
@@ -49,6 +50,42 @@ fn test_enum_struct_2() -> anyhow::Result<()> {
     let yaml = serde_saphyr::to_string(&value)?;
 
     let r: Outer = serde_saphyr::from_str(&yaml)?;
+    assert_eq!(value, r);
+
+    Ok(())
+}
+
+#[test]
+fn tuple_variant_round_trips_when_nested_under_a_key() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum E {
+        Tup(u8, u8, u8),
+    }
+
+    let value = BTreeMap::from([(
+        "hello".to_string(),
+        BTreeMap::from([("world".to_string(), E::Tup(1, 2, 3))]),
+    )]);
+    let yaml = serde_saphyr::to_string(&value)?;
+    let r: BTreeMap<String, BTreeMap<String, E>> = serde_saphyr::from_str(&yaml)?;
+    assert_eq!(value, r);
+
+    Ok(())
+}
+
+#[test]
+fn struct_variant_round_trips_when_nested_under_a_key() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum E {
+        Strukt { a: u8, b: u8 },
+    }
+
+    let value = BTreeMap::from([(
+        "hello".to_string(),
+        BTreeMap::from([("world".to_string(), E::Strukt { a: 1, b: 2 })]),
+    )]);
+    let yaml = serde_saphyr::to_string(&value)?;
+    let r: BTreeMap<String, BTreeMap<String, E>> = serde_saphyr::from_str(&yaml)?;
     assert_eq!(value, r);
 
     Ok(())

--- a/tests/en_structs.rs
+++ b/tests/en_structs.rs
@@ -1,4 +1,5 @@
 #![cfg(all(feature = "serialize", feature = "deserialize"))]
+use rstest::rstest;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -69,6 +70,38 @@ fn tuple_variant_round_trips_when_nested_under_a_key() -> anyhow::Result<()> {
     let yaml = serde_saphyr::to_string(&value)?;
     let r: BTreeMap<String, BTreeMap<String, E>> = serde_saphyr::from_str(&yaml)?;
     assert_eq!(value, r);
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+enum ComplexFieldEnum {
+    Tup(Box<ComplexFieldEnum>, Box<ComplexFieldEnum>),
+    Strukt { field: Box<ComplexFieldEnum> },
+    Seq(Vec<ComplexFieldEnum>),
+    Unit,
+}
+
+/// A tuple-variant whose first field is itself a complex node (a struct variant,
+/// a sequence, another tuple variant). Each field must keep its body indented
+/// under its own dash rather than dedenting to the dash column.
+#[rstest]
+#[case::struct_variant(ComplexFieldEnum::Strukt {
+    field: Box::new(ComplexFieldEnum::Unit),
+})]
+#[case::sequence(ComplexFieldEnum::Seq(vec![ComplexFieldEnum::Unit]))]
+#[case::tuple_variant(ComplexFieldEnum::Tup(
+    Box::new(ComplexFieldEnum::Unit),
+    Box::new(ComplexFieldEnum::Unit),
+))]
+fn tuple_variant_round_trips_with_complex_fields(
+    #[case] first_field: ComplexFieldEnum,
+) -> anyhow::Result<()> {
+    let value = ComplexFieldEnum::Tup(Box::new(first_field), Box::new(ComplexFieldEnum::Unit));
+    let yaml = serde_saphyr::to_string(&value)?;
+    let r: ComplexFieldEnum =
+        serde_saphyr::from_str(&yaml).map_err(|e| anyhow::anyhow!("{e}\n--- yaml ---\n{yaml}"))?;
+    assert_eq!(value, r, "round-trip mismatch for:\n{yaml}");
 
     Ok(())
 }


### PR DESCRIPTION
previously, `foo.bar: [1,2,3]` would serialise as:

```yaml
foo:
  bar:
- 1
- 2
- 3
```

while it should have done this instead:

```yaml
foo:
  bar:
  - 1
  - 2
  - 3
```