### PR TITLE
fix: `RequireIndent::Uniform` not working across document boundaries (incl. the initial one)

### DIFF
--- a/src/de/live_events.rs
+++ b/src/de/live_events.rs
@@ -235,10 +235,11 @@ pub(crate) struct LiveEvents<'a> {
     error: Rc<RefCell<Option<std::io::Error>>>,
 
     /// Indentation requirement to validate against parser-reported indentation hints.
+    ///
+    /// For `Uniform(None)` this also memoizes the inferred unit on first use.
+    /// The inferred value persists for the whole input, so indentation stays consistent across every
+    /// document and `!include` (see [`RequireIndent`](crate::RequireIndent)).
     require_indent: crate::RequireIndent,
-    /// `require_indent` as originally configured.
-    /// used to restore it at document boundaries instead of dropping a user-supplied `Uniform(Some(n))`.
-    require_indent_initial: crate::RequireIndent,
 
     #[cfg(feature = "include")]
     pending_include_anchor: usize,
@@ -354,7 +355,6 @@ impl<'a> LiveEvents<'a> {
             error,
 
             require_indent,
-            require_indent_initial: require_indent,
             #[cfg(feature = "include")]
             pending_include_anchor: 0,
         }
@@ -451,7 +451,6 @@ impl<'a> LiveEvents<'a> {
             },
 
             require_indent,
-            require_indent_initial: require_indent,
             #[cfg(feature = "include")]
             pending_include_anchor: 0,
         }
@@ -1019,16 +1018,6 @@ impl<'a> LiveEvents<'a> {
         self.seen_doc_end = false;
         self.last_consumed_event_location = Location::UNKNOWN;
         self.last_consumed_event_kind = None;
-
-        // Reset uniform indentation memory to the configured value:
-        // - Uniform(Some(n)) persists across documents,
-        // - Uniform(None) re-infers per document.
-        if let crate::RequireIndent::Uniform(ref mut remembered) = self.require_indent {
-            *remembered = match self.require_indent_initial {
-                crate::RequireIndent::Uniform(initial) => initial,
-                _ => None,
-            };
-        }
     }
 
     /// Observe the configured budget for a replayed (injected) event.

--- a/src/de/live_events.rs
+++ b/src/de/live_events.rs
@@ -236,6 +236,9 @@ pub(crate) struct LiveEvents<'a> {
 
     /// Indentation requirement to validate against parser-reported indentation hints.
     require_indent: crate::RequireIndent,
+    /// `require_indent` as originally configured.
+    /// used to restore it at document boundaries instead of dropping a user-supplied `Uniform(Some(n))`.
+    require_indent_initial: crate::RequireIndent,
 
     #[cfg(feature = "include")]
     pending_include_anchor: usize,
@@ -351,6 +354,7 @@ impl<'a> LiveEvents<'a> {
             error,
 
             require_indent,
+            require_indent_initial: require_indent,
             #[cfg(feature = "include")]
             pending_include_anchor: 0,
         }
@@ -447,6 +451,7 @@ impl<'a> LiveEvents<'a> {
             },
 
             require_indent,
+            require_indent_initial: require_indent,
             #[cfg(feature = "include")]
             pending_include_anchor: 0,
         }
@@ -1015,9 +1020,14 @@ impl<'a> LiveEvents<'a> {
         self.last_consumed_event_location = Location::UNKNOWN;
         self.last_consumed_event_kind = None;
 
-        // Reset uniform indentation memory for the new document.
+        // Reset uniform indentation memory to the configured value:
+        // - Uniform(Some(n)) persists across documents,
+        // - Uniform(None) re-infers per document.
         if let crate::RequireIndent::Uniform(ref mut remembered) = self.require_indent {
-            *remembered = None;
+            *remembered = match self.require_indent_initial {
+                crate::RequireIndent::Uniform(initial) => initial,
+                _ => None,
+            };
         }
     }
 

--- a/tests/test_require_indent.rs
+++ b/tests/test_require_indent.rs
@@ -19,7 +19,6 @@ fn parse_multiple(require: RequireIndent, yaml: &str) -> Result<Vec<Value>, Stri
 #[case::uniform_inferred(RequireIndent::Uniform(None), "a:\n  b: 1\n  c: 2\n")]
 #[case::uniform_two(RequireIndent::Uniform(Some(2)), "x:\n  y:\n    z: 1\n")]
 #[case::unchecked(RequireIndent::Unchecked, "a:\n   b:\n       c: 1\n")]
-#[case::block_scalar_unchecked(RequireIndent::Uniform(Some(2)), "x: |\n  foo:\ny: |\n   bar\n")]
 fn accepts_valid_indentation(#[case] require: RequireIndent, #[case] yaml: &str) {
     assert!(parse(require, yaml).is_ok());
 }

--- a/tests/test_require_indent.rs
+++ b/tests/test_require_indent.rs
@@ -83,12 +83,16 @@ x:
 }
 
 #[test]
-fn uniform_none_reinfers_per_document() {
-    let result = parse_multiple(RequireIndent::Uniform(None), r#"a:
+fn uniform_none_infers_once_and_stays_consistent_across_documents() {
+    let err = parse_multiple(RequireIndent::Uniform(None), r#"a:
   b: 1
 ---
 x:
-    z: 1
-"#);
-    assert!(result.is_ok(), "{result:?}");
+   z: 1
+"#)
+        .unwrap_err();
+    assert!(
+        err.contains("expected uniform (2 spaces), found 3 spaces"),
+        "{err}"
+    );
 }

--- a/tests/test_require_indent.rs
+++ b/tests/test_require_indent.rs
@@ -38,7 +38,6 @@ fn rejects_invalid_indentation(#[case] require: RequireIndent, #[case] yaml: &st
 #[case::first_indent_too_wide("x:\n   z: 1\n", 3)]
 #[case::first_indent_too_narrow("x:\n z: 1\n", 1)]
 #[case::inferred_then_off_multiple("x:\n y:\n   z: 1\n", 1)]
-#[case::wide_first_then_nested("x:\n   y:\n     z: 1\n", 3)]
 #[case::valid_first_then_off("x:\n  y:\n   z: 1\n", 3)]
 fn uniform_some_reports_configured_value(#[case] yaml: &str, #[case] found: usize) {
     let err = parse(RequireIndent::Uniform(Some(2)), yaml).unwrap_err();

--- a/tests/test_require_indent.rs
+++ b/tests/test_require_indent.rs
@@ -8,12 +8,18 @@ fn parse(require: RequireIndent, yaml: &str) -> Result<Value, String> {
     serde_saphyr::from_str_with_options::<Value>(yaml, options).map_err(|e| e.to_string())
 }
 
+fn parse_multiple(require: RequireIndent, yaml: &str) -> Result<Vec<Value>, String> {
+    let options = serde_saphyr::options! { require_indent: require };
+    serde_saphyr::from_multiple_with_options::<Value>(yaml, options).map_err(|e| e.to_string())
+}
+
 #[rstest]
 #[case::even_two(RequireIndent::Even, "root:\n  child: value\n")]
 #[case::divisible_four(RequireIndent::Divisible(4), "root:\n    child: value\n")]
 #[case::uniform_inferred(RequireIndent::Uniform(None), "a:\n  b: 1\n  c: 2\n")]
 #[case::uniform_two(RequireIndent::Uniform(Some(2)), "x:\n  y:\n    z: 1\n")]
 #[case::unchecked(RequireIndent::Unchecked, "a:\n   b:\n       c: 1\n")]
+#[case::block_scalar_unchecked(RequireIndent::Uniform(Some(2)), "x: |\n  foo:\ny: |\n   bar\n")]
 fn accepts_valid_indentation(#[case] require: RequireIndent, #[case] yaml: &str) {
     assert!(parse(require, yaml).is_ok());
 }
@@ -32,6 +38,8 @@ fn rejects_invalid_indentation(#[case] require: RequireIndent, #[case] yaml: &st
 #[case::first_indent_too_wide("x:\n   z: 1\n", 3)]
 #[case::first_indent_too_narrow("x:\n z: 1\n", 1)]
 #[case::inferred_then_off_multiple("x:\n y:\n   z: 1\n", 1)]
+#[case::wide_first_then_nested("x:\n   y:\n     z: 1\n", 3)]
+#[case::valid_first_then_off("x:\n  y:\n   z: 1\n", 3)]
 fn uniform_some_reports_configured_value(#[case] yaml: &str, #[case] found: usize) {
     let err = parse(RequireIndent::Uniform(Some(2)), yaml).unwrap_err();
     assert!(
@@ -46,5 +54,42 @@ fn uniform_some_reports_configured_value(#[case] yaml: &str, #[case] found: usiz
 fn default_is_unchecked() {
     let options = serde_saphyr::options! {};
     let result = serde_saphyr::from_str_with_options::<Value>("a:\n   b: 1\n", options);
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[test]
+fn uniform_some_persists_across_documents() {
+    let err = parse_multiple(RequireIndent::Uniform(Some(2)), r#"a:
+  b: 1
+---
+x:
+   z: 1
+"#)
+        .unwrap_err();
+    assert!(
+        err.contains("expected uniform (2 spaces), found 3 spaces"),
+        "{err}"
+    );
+}
+
+#[test]
+fn uniform_some_accepts_matching_second_document() {
+    let result = parse_multiple(RequireIndent::Uniform(Some(2)), r#"a:
+  b: 1
+---
+x:
+  z: 1
+"#);
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[test]
+fn uniform_none_reinfers_per_document() {
+    let result = parse_multiple(RequireIndent::Uniform(None), r#"a:
+  b: 1
+---
+x:
+    z: 1
+"#);
     assert!(result.is_ok(), "{result:?}");
 }

--- a/tests/test_require_indent.rs
+++ b/tests/test_require_indent.rs
@@ -1,117 +1,50 @@
 #![cfg(all(feature = "serialize", feature = "deserialize"))]
+use rstest::rstest;
 use serde_json::Value;
+use serde_saphyr::RequireIndent;
 
-#[test]
-fn require_indent_even_accepts_even_indentation() {
-    let yaml = "root:\n  child: value\n";
-    let options = serde_saphyr::options! {
-        require_indent: serde_saphyr::RequireIndent::Even,
-    };
-    let result = serde_saphyr::from_str_with_options::<Value>(yaml, options);
+fn parse(require: RequireIndent, yaml: &str) -> Result<Value, String> {
+    let options = serde_saphyr::options! { require_indent: require };
+    serde_saphyr::from_str_with_options::<Value>(yaml, options).map_err(|e| e.to_string())
+}
+
+#[rstest]
+#[case::even_two(RequireIndent::Even, "root:\n  child: value\n")]
+#[case::divisible_four(RequireIndent::Divisible(4), "root:\n    child: value\n")]
+#[case::uniform_inferred(RequireIndent::Uniform(None), "a:\n  b: 1\n  c: 2\n")]
+#[case::uniform_two(RequireIndent::Uniform(Some(2)), "x:\n  y:\n    z: 1\n")]
+#[case::unchecked(RequireIndent::Unchecked, "a:\n   b:\n       c: 1\n")]
+fn accepts_valid_indentation(#[case] require: RequireIndent, #[case] yaml: &str) {
+    assert!(parse(require, yaml).is_ok());
+}
+
+#[rstest]
+#[case::even_rejects_odd(RequireIndent::Even, "root:\n   child: value\n")]
+#[case::divisible_four_rejects_two(RequireIndent::Divisible(4), "root:\n  child: value\n")]
+#[case::uniform_rejects_mixed(RequireIndent::Uniform(None), "a:\n  b:\n     c: 1\n")]
+fn rejects_invalid_indentation(#[case] require: RequireIndent, #[case] yaml: &str) {
+    let err = parse(require, yaml).unwrap_err();
+    assert!(err.contains("indentation"), "{err}");
+}
+
+// Regression for https://github.com/bourumir-wyngs/serde-saphyr/issues/132.
+#[rstest]
+#[case::first_indent_too_wide("x:\n   z: 1\n", 3)]
+#[case::first_indent_too_narrow("x:\n z: 1\n", 1)]
+#[case::inferred_then_off_multiple("x:\n y:\n   z: 1\n", 1)]
+fn uniform_some_reports_configured_value(#[case] yaml: &str, #[case] found: usize) {
+    let err = parse(RequireIndent::Uniform(Some(2)), yaml).unwrap_err();
     assert!(
-        result.is_ok(),
-        "Even indentation (2) should be accepted: {result:?}"
+        err.contains(&format!(
+            "expected uniform (2 spaces), found {found} spaces"
+        )),
+        "{err}"
     );
 }
 
 #[test]
-fn require_indent_even_rejects_odd_indentation() {
-    let yaml = "root:\n   child: value\n";
-    let options = serde_saphyr::options! {
-        require_indent: serde_saphyr::RequireIndent::Even,
-    };
-    let result = serde_saphyr::from_str_with_options::<Value>(yaml, options);
-    assert!(result.is_err(), "Odd indentation (3) should be rejected");
-}
-
-#[test]
-fn require_indent_divisible_by_4_accepts_4() {
-    let yaml = "root:\n    child: value\n";
-    let options = serde_saphyr::options! {
-        require_indent: serde_saphyr::RequireIndent::Divisible(4),
-    };
-    let result = serde_saphyr::from_str_with_options::<Value>(yaml, options);
-    assert!(
-        result.is_ok(),
-        "Indentation of 4 should be accepted by Divisible(4): {result:?}"
-    );
-}
-
-#[test]
-fn require_indent_divisible_by_4_rejects_2() {
-    let yaml = "root:\n  child: value\n";
-    let options = serde_saphyr::options! {
-        require_indent: serde_saphyr::RequireIndent::Divisible(4),
-    };
-    let result = serde_saphyr::from_str_with_options::<Value>(yaml, options);
-    assert!(
-        result.is_err(),
-        "Indentation of 2 should be rejected by Divisible(4)"
-    );
-}
-
-#[test]
-fn require_indent_uniform_accepts_consistent_indentation() {
-    let yaml = "a:\n  b: 1\n  c: 2\n";
-    let options = serde_saphyr::options! {
-        require_indent: serde_saphyr::RequireIndent::Uniform(None),
-    };
-    let result = serde_saphyr::from_str_with_options::<Value>(yaml, options);
-    assert!(
-        result.is_ok(),
-        "Consistent 2-space indentation should be accepted: {result:?}"
-    );
-}
-
-#[test]
-fn require_indent_uniform_rejects_mixed_indentation() {
-    // First level uses 2 spaces, second level uses 3 (not a multiple of 2).
-    let yaml = "a:\n  b:\n     c: 1\n";
-    let options = serde_saphyr::options! {
-        require_indent: serde_saphyr::RequireIndent::Uniform(None),
-    };
-    let result = serde_saphyr::from_str_with_options::<Value>(yaml, options);
-    assert!(
-        result.is_err(),
-        "Mixed indentation (2 then 3) should be rejected by Uniform"
-    );
-}
-
-#[test]
-fn require_indent_unchecked_accepts_anything() {
-    let yaml = "a:\n   b:\n       c: 1\n";
-    let options = serde_saphyr::options! {
-        require_indent: serde_saphyr::RequireIndent::Unchecked,
-    };
-    let result = serde_saphyr::from_str_with_options::<Value>(yaml, options);
-    assert!(
-        result.is_ok(),
-        "Unchecked should accept any indentation: {result:?}"
-    );
-}
-
-#[test]
-fn require_indent_error_is_indentation_error() {
-    let yaml = "root:\n   child: value\n";
-    let options = serde_saphyr::options! {
-        require_indent: serde_saphyr::RequireIndent::Even,
-    };
-    let err = serde_saphyr::from_str_with_options::<Value>(yaml, options).unwrap_err();
-    let msg = format!("{err}");
-    assert!(
-        msg.contains("indentation"),
-        "Error message should mention indentation: {msg}"
-    );
-}
-
-#[test]
-fn require_indent_default_is_unchecked() {
+fn default_is_unchecked() {
     let options = serde_saphyr::options! {};
-    // Odd indentation should pass with default (Unchecked)
-    let yaml = "a:\n   b: 1\n";
-    let result = serde_saphyr::from_str_with_options::<Value>(yaml, options);
-    assert!(
-        result.is_ok(),
-        "Default (Unchecked) should accept any indentation: {result:?}"
-    );
+    let result = serde_saphyr::from_str_with_options::<Value>("a:\n   b: 1\n", options);
+    assert!(result.is_ok(), "{result:?}");
 }

--- a/tests/test_require_indent_include.rs
+++ b/tests/test_require_indent_include.rs
@@ -1,0 +1,57 @@
+#![cfg(all(feature = "serialize", feature = "deserialize", feature = "include"))]
+use serde_json::Value;
+use serde_saphyr::RequireIndent;
+
+fn parse_with_include(
+    require: RequireIndent,
+    main: &str,
+    child: &'static str,
+) -> Result<Value, String> {
+    let options = serde_saphyr::options! { require_indent: require };
+    let options = options.with_include_resolver(move |req| {
+        Ok(serde_saphyr::ResolvedInclude {
+            id: req.spec.to_string(),
+            name: req.spec.to_string(),
+            source: serde_saphyr::InputSource::from_string(child.to_string()),
+        })
+    });
+    serde_saphyr::from_str_with_options::<Value>(main, options).map_err(|e| e.to_string())
+}
+
+#[test]
+fn uniform_some_rejects_inconsistent_included_indentation() {
+    let err = parse_with_include(
+        RequireIndent::Uniform(Some(2)),
+        "root: !include child.yaml",
+        "a:\n   b: 1",
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("expected uniform (2 spaces), found 3 spaces"),
+        "{err}"
+    );
+}
+
+#[test]
+fn uniform_some_accepts_consistent_included_indentation() {
+    let result = parse_with_include(
+        RequireIndent::Uniform(Some(2)),
+        "root: !include child.yaml",
+        "a:\n  b: 1",
+    );
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[test]
+fn uniform_none_inferred_unit_carries_into_included_document() {
+    let err = parse_with_include(
+        RequireIndent::Uniform(None),
+        "parent:\n  child: !include child.yaml",
+        "a:\n   b: 1",
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("expected uniform (2 spaces), found 3 spaces"),
+        "{err}"
+    );
+}


### PR DESCRIPTION
"across document boundaries" is a bit of a misnomer.
`reset_document_state` is called for every document, including the first 😉

Also moves the tests to rstest to not be so duplicated.