### PR TITLE
fix: quoting support not counting trailing whitespace in keys, BOM, ..

### DIFF
--- a/fuzz/fuzz_targets/serialize.rs
+++ b/fuzz/fuzz_targets/serialize.rs
@@ -54,8 +54,7 @@ fn gen_node(u: &mut Unstructured, depth: u32) -> arbitrary::Result<Node> {
             let n = u.int_in_range(0..=MAX_BREADTH)?;
             let mut m = BTreeMap::new();
             for _ in 0..n {
-                // TODO: We need to trim here because trailing newlines and spaces are intentionally
-                let k = String::arbitrary(u)?.trim().to_string();
+                let k = String::arbitrary(u)?;
                 let val = gen_node(u, depth - 1)?;
                 m.insert(k, val);
             }
@@ -82,7 +81,9 @@ fuzz_target!(|node: Node| {
     let _: Node = match serde_saphyr::from_str(&text) {
         Ok(back) => back,
         Err(e) => {
-            panic!("serializer emitted YAML that fails to parse back: {e}\n--- yaml ---\n{text}")
+            panic!(
+                "serializer emitted YAML that fails to parse back:\n---error---\n{e}\n--- yaml ---\n{text}\n---debug---\n{node:#?}"
+            )
         }
     };
 

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -456,7 +456,8 @@ mod tests {
     #[rstest]
     #[case::dash_no_space("-value")]
     #[case::question_no_space("?query")]
-    fn plain_keys_allow_indicator_without_following_whitespace(#[case] input: &str) {
+    #[case::interior_space("a b")]
+    fn plain_keys_allow_safe_inputs(#[case] input: &str) {
         assert!(is_plain_safe(input), "{input:?}");
     }
 
@@ -466,11 +467,5 @@ mod tests {
     #[case::trailing_tab("foo\t")]
     fn plain_keys_reject_surrounding_whitespace(#[case] input: &str) {
         assert!(!is_plain_safe(input), "{input:?}");
-    }
-
-    #[rstest]
-    #[case::interior_space("a b")]
-    fn plain_keys_allow_interior_whitespace(#[case] input: &str) {
-        assert!(is_plain_safe(input), "{input:?}");
     }
 }

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -253,7 +253,7 @@ pub(crate) fn is_plain_safe(s: &str) -> bool {
         return false;
     }
     let bytes = s.as_bytes();
-    if bytes[0].is_ascii_whitespace() {
+    if bytes[0].is_ascii_whitespace() || bytes[bytes.len() - 1].is_ascii_whitespace() {
         return false;
     }
 
@@ -292,7 +292,7 @@ pub(crate) fn is_plain_value_safe(s: &str, yaml_12: bool, in_flow: bool) -> bool
     }
 
     let bytes = s.as_bytes();
-    if bytes[0].is_ascii_whitespace() {
+    if bytes[0].is_ascii_whitespace() || bytes[bytes.len() - 1].is_ascii_whitespace() {
         return false;
     }
 
@@ -452,6 +452,20 @@ mod tests {
     #[case::dash_no_space("-value")]
     #[case::question_no_space("?query")]
     fn plain_keys_allow_indicator_without_following_whitespace(#[case] input: &str) {
+        assert!(is_plain_safe(input), "{input:?}");
+    }
+
+    #[rstest]
+    #[case::trailing_space("foo ")]
+    #[case::leading_space(" foo")]
+    #[case::trailing_tab("foo\t")]
+    fn plain_keys_reject_surrounding_whitespace(#[case] input: &str) {
+        assert!(!is_plain_safe(input), "{input:?}");
+    }
+
+    #[rstest]
+    #[case::interior_space("a b")]
+    fn plain_keys_allow_interior_whitespace(#[case] input: &str) {
         assert!(is_plain_safe(input), "{input:?}");
     }
 }

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -253,7 +253,12 @@ pub(crate) fn is_plain_safe(s: &str) -> bool {
         return false;
     }
     let bytes = s.as_bytes();
-    if bytes[0].is_ascii_whitespace() || bytes[bytes.len() - 1].is_ascii_whitespace() {
+    // Keys with leading or trailing whitespace must be quoted:
+    // Unlike values, a key's surrounding whitespace is not preserved across a round trip
+    // (e.g. `foo : x` and `foo: x` parse to the same key), so a plain scalar would silently collapse distinct keys.
+    if bytes.first().is_some_and(u8::is_ascii_whitespace)
+        || bytes.last().is_some_and(u8::is_ascii_whitespace)
+    {
         return false;
     }
 
@@ -281,7 +286,11 @@ pub(crate) fn is_plain_safe(s: &str) -> bool {
 }
 
 /// Returns true if `s` can be emitted as a plain scalar in VALUE position without quoting.
-/// This is slightly more permissive than `is_plain_safe` for keys: it allows ':' inside values.
+///
+/// This is slightly more permissive than `is_plain_safe` for keys:
+/// - it allows ':' inside values
+/// - trailing whitespace is allowed
+///
 /// Additionally, we make this stricter for strings that appear inside flow-style sequences/maps
 /// where certain characters would break parsing (e.g., commas and brackets) or where the token
 /// could be misinterpreted as a number or boolean.
@@ -292,23 +301,19 @@ pub(crate) fn is_plain_value_safe(s: &str, yaml_12: bool, in_flow: bool) -> bool
     }
 
     let bytes = s.as_bytes();
-    if bytes[0].is_ascii_whitespace() || bytes[bytes.len() - 1].is_ascii_whitespace() {
+    if bytes.first().is_some_and(u8::is_ascii_whitespace) {
         return false;
     }
 
-    match bytes[0] {
-        b'-' | b'?' => {
-            if bytes.len() == 1 {
-                return false;
-            }
-            if bytes[1].is_ascii_whitespace() {
-                return false;
-            }
-        }
+    match bytes {
+        [b'-' | b'?'] => return false,
+        [b'-' | b'?', b1, ..] if b1.is_ascii_whitespace() => return false,
         // ',' is a flow indicator and cannot start a plain scalar.
-        b',' => return false,
-        b':' | b'[' | b']' | b'{' | b'}' | b'#' | b'&' | b'*' | b'!' | b'|' | b'>' | b'\''
-        | b'"' | b'%' | b'@' | b'`' => return false,
+        [
+            b',' | b':' | b'[' | b']' | b'{' | b'}' | b'#' | b'&' | b'*' | b'!' | b'|' | b'>'
+            | b'\'' | b'"' | b'%' | b'@' | b'`',
+            ..,
+        ] => return false,
         _ => {}
     }
 

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -374,15 +374,25 @@ pub(crate) fn is_auto_block_scalar_readable(s: &str) -> bool {
     !s.is_empty()
 }
 
+/// Characters that cannot survive a round-trip inside a plain or single-quoted
+/// scalar and therefore force double-quoted emission.
+/// `char::is_control` misses BOM (U+FEFF) and the LS/PS separators (U+2028/U+2029), which are not controls.
+#[inline]
+pub(crate) fn is_controll_which_needs_escaping(ch: char) -> bool {
+    ch.is_control() || matches!(ch, '\u{FEFF}' | '\u{2028}' | '\u{2029}')
+}
+
 fn contains_any_or_is_control(string: &str, values: &[char]) -> bool {
     string
         .chars()
-        .any(|x| values.iter().any(|v| &x == v || x.is_control()))
+        .any(|x| is_controll_which_needs_escaping(x) || values.iter().any(|v| &x == v))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{is_numeric_looking, is_plain_safe};
+    use super::{
+        is_controll_which_needs_escaping, is_numeric_looking, is_plain_safe, is_plain_value_safe,
+    };
     use rstest::rstest;
 
     #[rstest]
@@ -467,5 +477,44 @@ mod tests {
     #[case::trailing_tab("foo\t")]
     fn plain_keys_reject_surrounding_whitespace(#[case] input: &str) {
         assert!(!is_plain_safe(input), "{input:?}");
+    }
+
+    #[rstest]
+    #[case::nul('\0')]
+    #[case::tab('\t')]
+    #[case::newline('\n')]
+    #[case::carriage_return('\r')]
+    #[case::nel('\u{0085}')]
+    #[case::bom('\u{FEFF}')]
+    #[case::line_sep('\u{2028}')]
+    #[case::para_sep('\u{2029}')]
+    fn chars_needing_escaping(#[case] ch: char) {
+        assert!(is_controll_which_needs_escaping(ch), "{ch:?} should escape");
+    }
+
+    #[rstest]
+    #[case::ascii('a')]
+    #[case::space(' ')]
+    #[case::unicode('é')]
+    #[case::cjk('字')]
+    fn chars_not_needing_escaping(#[case] ch: char) {
+        assert!(
+            !is_controll_which_needs_escaping(ch),
+            "{ch:?} should stay plain"
+        );
+    }
+
+    #[rstest]
+    #[case::bom("\u{FEFF}")]
+    #[case::bom_prefixed("\u{FEFF}key")]
+    #[case::line_sep("a\u{2028}b")]
+    #[case::para_sep("a\u{2029}b")]
+    fn format_chars_are_not_plain_safe(#[case] input: &str) {
+        assert!(!is_plain_safe(input), "key {input:?}");
+        assert!(!is_plain_value_safe(input, false, false), "value {input:?}");
+        assert!(
+            !is_plain_value_safe(input, true, true),
+            "flow value {input:?}"
+        );
     }
 }

--- a/src/ser/quoting.rs
+++ b/src/ser/quoting.rs
@@ -252,6 +252,10 @@ pub(crate) fn is_plain_safe(s: &str) -> bool {
     if is_ambiguous(s) {
         return false;
     }
+    // A plain, untagged "<<" key would be a YAML merge key, not the literal string "<<".
+    if s == "<<" {
+        return false;
+    }
     let bytes = s.as_bytes();
     // Keys with leading or trailing whitespace must be quoted:
     // Unlike values, a key's surrounding whitespace is not preserved across a round trip
@@ -457,13 +461,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case::dash_space("- value")]
-    #[case::question_tab("?\tvalue")]
-    fn plain_keys_reject_indicator_followed_by_whitespace(#[case] input: &str) {
-        assert!(!is_plain_safe(input), "{input:?}");
-    }
-
-    #[rstest]
     #[case::dash_no_space("-value")]
     #[case::question_no_space("?query")]
     #[case::interior_space("a b")]
@@ -472,10 +469,13 @@ mod tests {
     }
 
     #[rstest]
+    #[case::dash_indicator_space("- value")]
+    #[case::question_indicator_tab("?\tvalue")]
     #[case::trailing_space("foo ")]
     #[case::leading_space(" foo")]
     #[case::trailing_tab("foo\t")]
-    fn plain_keys_reject_surrounding_whitespace(#[case] input: &str) {
+    #[case::merge_key("<<")]
+    fn plain_keys_reject_unsafe_inputs(#[case] input: &str) {
         assert!(!is_plain_safe(input), "{input:?}");
     }
 

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -18,6 +18,7 @@ use crate::long_strings::{NAME_FOLD_STR, NAME_LIT_STR};
 use super::options::{CommentPosition, FOLDED_WRAP_CHARS, MIN_FOLD_CHARS, SerializerOptions};
 use super::quoting::{
     is_auto_block_scalar_readable, is_block_scalar_content_safe, is_plain_safe, is_plain_value_safe,
+    is_controll_which_needs_escaping,
 };
 use super::{
     Error, NAME_FLOW_MAP, NAME_FLOW_SEQ, NAME_SPACE_AFTER, NAME_TUPLE_ANCHOR, NAME_TUPLE_COMMENTED,
@@ -216,7 +217,7 @@ impl<'a, W: Write> YamlSerializer<'a, W> {
         s.chars().any(|c| {
             c == '\''       // single quote present - cannot use single-quoted style
                 || c == '\\' // backslash - needs escape processing
-                || c.is_control() // control chars (includes \n, \t, \r, etc.) need escaping
+                || is_controll_which_needs_escaping(c) // control chars (includes \n, \t, \r, etc.) need escaping
         })
     }
 

--- a/tests/key_quoting.rs
+++ b/tests/key_quoting.rs
@@ -49,6 +49,21 @@ mod tests {
         assert_eq!(parsed, h, "Comma key/value did not round-trip as expected");
     }
 
+    #[test]
+    fn whitespace_padded_keys_roundtrip() {
+        let mut h = HashMap::new();
+        // if we were to trim or not quote the keys, they would collapse
+        h.insert("foo ".to_string(), "trailing".to_string());
+        h.insert("foo".to_string(), "bare".to_string());
+        h.insert(" foo".to_string(), "leading".to_string());
+        h.insert("foo bar".to_string(), "inner".to_string());
+
+        let yaml = to_string(&h).expect("serialize HashMap with whitespace-padded keys");
+
+        let parsed: HashMap<String, String> = from_str(&yaml).unwrap();
+        assert_eq!(parsed, h);
+    }
+
     /// Ensures that string keys that look like numbers ("1", "2.42") are quoted
     /// during serialization so they round-trip as strings, not numbers.
     #[test]

--- a/tests/ser_coverage_boost.rs
+++ b/tests/ser_coverage_boost.rs
@@ -581,7 +581,7 @@ fn auto_literal_for_multiline_string() {
 fn auto_folded_for_long_single_line() {
     // A very long single-line string should auto-select folded block style
     let long = "word ".repeat(30); // 150 chars
-    let yaml = to_string(&long).unwrap();
+    let yaml = to_string(&long.trim_end()).unwrap();
     assert!(yaml.contains('>'), "expected auto folded block: {yaml}");
 }
 

--- a/tests/ser_coverage_boost.rs
+++ b/tests/ser_coverage_boost.rs
@@ -581,7 +581,7 @@ fn auto_literal_for_multiline_string() {
 fn auto_folded_for_long_single_line() {
     // A very long single-line string should auto-select folded block style
     let long = "word ".repeat(30); // 150 chars
-    let yaml = to_string(&long.trim_end()).unwrap();
+    let yaml = to_string(&long).unwrap();
     assert!(yaml.contains('>'), "expected auto folded block: {yaml}");
 }
 


### PR DESCRIPTION
when I have a map `{"foo ": [],"foo": []}`, the keys get their "" removed, so invalid yaml gets serialised.

This PR fixes this oversight