### PR TITLE
fix: long string keys not roundtripping

### DIFF
--- a/fuzz/fuzz_targets/serialize.rs
+++ b/fuzz/fuzz_targets/serialize.rs
@@ -89,7 +89,7 @@ fuzz_target!(|node: Node| {
     };
 
     // anything we emit must be parseable YAML for this model.
-    let _: Node = match serde_saphyr::from_str(&text) {
+    let back: Node = match serde_saphyr::from_str(&text) {
         Ok(back) => back,
         Err(e) => {
             panic!(
@@ -98,5 +98,10 @@ fuzz_target!(|node: Node| {
         }
     };
 
-    // todo: equality, roundtrip, indepotance
+    // equality
+    assert_eq!(
+        node, back,
+        "round-trip changed the value\n--- yaml ---\n{text}\n--- original ---\n{node:#?}\n--- decoded ---\n{back:#?}"
+    );
+    // todo: indepotance
 });

--- a/fuzz/fuzz_targets/serialize.rs
+++ b/fuzz/fuzz_targets/serialize.rs
@@ -83,10 +83,7 @@ impl<'a> Arbitrary<'a> for Node {
 fuzz_target!(|node: Node| {
     let opts = serde_saphyr::ser_options! {};
     // serialization is panic-free and from valid input, so may never return an `Err`
-    let text = match serde_saphyr::to_string_with_options(&node, opts) {
-        Ok(text) => text,
-        Err(e) => panic!("{e}"),
-    };
+    let text = serde_saphyr::to_string_with_options(&node, opts).unwrap();
 
     // anything we emit must be parseable YAML for this model.
     let back: Node = match serde_saphyr::from_str(&text) {
@@ -103,5 +100,11 @@ fuzz_target!(|node: Node| {
         node, back,
         "round-trip changed the value\n--- yaml ---\n{text}\n--- original ---\n{node:#?}\n--- decoded ---\n{back:#?}"
     );
-    // todo: indepotance
+
+    // idempotence
+    let text2 = serde_saphyr::to_string_with_options(&back, opts).unwrap();
+    assert_eq!(
+        text, text2,
+        "serialization is not idempotent\n--- first ---\n{text}\n--- second ---\n{text2}\n--- value ---\n{node:#?}"
+    );
 });

--- a/fuzz/fuzz_targets/serialize.rs
+++ b/fuzz/fuzz_targets/serialize.rs
@@ -22,6 +22,17 @@ enum Node {
     Map(BTreeMap<String, Node>),
 }
 
+/// Generate a map key which occasionally is overly-long to ensure `? key` paths are triggered.
+fn gen_key(u: &mut Unstructured) -> arbitrary::Result<String> {
+    let key = String::arbitrary(u)?;
+    if u.ratio(1, 8)? {
+        let seed = if key.is_empty() { "k" } else { key.as_str() };
+        Ok(seed.repeat(1024 / seed.len() + 2))
+    } else {
+        Ok(key)
+    }
+}
+
 fn gen_node(u: &mut Unstructured, depth: u32) -> arbitrary::Result<Node> {
     // At depth 0, only scalar variants are allowed
     let max_variant: u32 = if depth == 0 { 3 } else { 7 };
@@ -54,7 +65,7 @@ fn gen_node(u: &mut Unstructured, depth: u32) -> arbitrary::Result<Node> {
             let n = u.int_in_range(0..=MAX_BREADTH)?;
             let mut m = BTreeMap::new();
             for _ in 0..n {
-                let k = String::arbitrary(u)?;
+                let k = gen_key(u)?;
                 let val = gen_node(u, depth - 1)?;
                 m.insert(k, val);
             }

--- a/src/ser/compound.rs
+++ b/src/ser/compound.rs
@@ -4,10 +4,17 @@ use serde::ser::{
 };
 use std::fmt::Write;
 
-use super::helpers::{scalar_key_to_string, BoolCapture, StrCapture, UsizeCapture};
+use super::helpers::{BoolCapture, StrCapture, UsizeCapture, scalar_key_to_string};
 use super::{AnchorId, YamlSerializer};
 use crate::ser::options::CommentPosition;
 use crate::ser::{Error, Result};
+
+/// From the spec:
+///
+/// > If the "?" indicator is omitted, parsing needs to see past the implicit key to recognize it as such.
+/// > To limit the amount of lookahead required, the ":" indicator must appear at most 1024 Unicode characters beyond the start of the key.
+/// > In addition, the key is restricted to a single line.
+const SIMPLE_KEY_MAX_LEN: usize = 1024;
 
 // ------------------------------------------------------------
 // Seq / Tuple serializers
@@ -386,6 +393,64 @@ pub struct MapSer<'a, 'b, W: Write> {
     pub(super) inline_value_start: bool,
 }
 
+impl<'a, 'b, W: Write> MapSer<'a, 'b, W> {
+    /// Emit a scalar key inline as `key:`.
+    fn write_simple_key(&mut self, text: &str) -> Result<()> {
+        // Indent continuation lines. If this map started inline after a dash,
+        // align under the first key by adding two spaces instead of a full indent step.
+        if self.align_after_dash && self.ser.at_line_start {
+            let base = self.depth.saturating_sub(1);
+            for _ in 0..self.ser.indent_step * base {
+                self.ser.out.write_char(' ')?;
+            }
+            self.ser.out.write_str("  ")?; // width of "- "
+            self.ser.at_line_start = false;
+        } else {
+            self.ser.write_indent(self.depth)?;
+        }
+        self.ser.out.write_str(text)?;
+        self.ser.out.write_str(":")?;
+        self.ser.pending_space_after_colon = true;
+        self.ser.at_line_start = false;
+        self.last_key_complex = false;
+        Ok(())
+    }
+
+    /// Emit a key using the explicit `? key` form; the value follows on a `: value` line.
+    fn write_explicit_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<()> {
+        self.ser.write_anchor_for_complex_node()?;
+        self.ser.write_indent(self.depth)?;
+        self.ser.out.write_str("? ")?;
+        self.ser.at_line_start = false;
+
+        let saved_depth = self.ser.depth;
+        let saved_current_map_depth = self.ser.current_map_depth;
+        let saved_pending_inline_map = self.ser.pending_inline_map;
+        let saved_inline_map_after_dash = self.ser.inline_map_after_dash;
+        let saved_after_dash_depth = self.ser.after_dash_depth;
+
+        self.ser.pending_inline_map = true;
+        self.ser.depth = self.depth;
+        // Provide a base depth for nested maps within this complex key so that
+        // continuation lines indent one level deeper than the parent mapping.
+        self.ser.current_map_depth = Some(self.depth);
+        self.ser.after_dash_depth = None;
+        key.serialize(&mut *self.ser)?;
+
+        self.ser.depth = saved_depth;
+        self.ser.current_map_depth = saved_current_map_depth;
+        self.ser.pending_inline_map = saved_pending_inline_map;
+        self.ser.inline_map_after_dash = saved_inline_map_after_dash;
+        self.ser.after_dash_depth = saved_after_dash_depth;
+        // A complex key may have been serialized as a block collection, which sets
+        // `last_value_was_block`. That state must NOT affect the *value* of this same
+        // map entry (e.g. we still want `: x: 3` inline for composite-key maps).
+        self.ser.last_value_was_block = false;
+        self.last_key_complex = true;
+        Ok(())
+    }
+}
+
 impl<'a, 'b, W: Write> SerializeMap for MapSer<'a, 'b, W> {
     type Ok = ();
     type Error = Error;
@@ -422,56 +487,16 @@ impl<'a, 'b, W: Write> SerializeMap for MapSer<'a, 'b, W> {
             self.ser.last_value_was_block = false;
 
             match scalar_key_to_string(key, self.ser.yaml_12) {
-                Ok(text) => {
-                    // Indent continuation lines. If this map started inline after a dash,
-                    // align under the first key by adding two spaces instead of a full indent step.
-                    if self.align_after_dash && self.ser.at_line_start {
-                        let base = self.depth.saturating_sub(1);
-                        for _ in 0..self.ser.indent_step * base {
-                            self.ser.out.write_char(' ')?;
-                        }
-                        self.ser.out.write_str("  ")?; // width of "- "
-                        self.ser.at_line_start = false;
-                    } else {
-                        self.ser.write_indent(self.depth)?;
-                    }
-                    self.ser.out.write_str(&text)?;
-                    // Defer the decision to put a space vs. newline until we see the value type.
-                    self.ser.out.write_str(":")?;
-                    self.ser.pending_space_after_colon = true;
-                    self.ser.at_line_start = false;
-                    self.last_key_complex = false;
+              Ok(text)
+              // since a utf8 "character" is at min one byte, text.len() is an cheap upper bound on the number of chars
+                    if text.len() <= SIMPLE_KEY_MAX_LEN
+                        || text.chars().count() <= SIMPLE_KEY_MAX_LEN =>
+                {
+                    self.write_simple_key(&text)?;
                 }
+                Ok(_) => self.write_explicit_key(key)?,
                 Err(Error::Unexpected { msg }) if msg == "non-scalar key" => {
-                    self.ser.write_anchor_for_complex_node()?;
-                    self.ser.write_indent(self.depth)?;
-                    self.ser.out.write_str("? ")?;
-                    self.ser.at_line_start = false;
-
-                    let saved_depth = self.ser.depth;
-                    let saved_current_map_depth = self.ser.current_map_depth;
-                    let saved_pending_inline_map = self.ser.pending_inline_map;
-                    let saved_inline_map_after_dash = self.ser.inline_map_after_dash;
-                    let saved_after_dash_depth = self.ser.after_dash_depth;
-
-                    self.ser.pending_inline_map = true;
-                    self.ser.depth = self.depth;
-                    // Provide a base depth for nested maps within this complex key so that
-                    // continuation lines indent one level deeper than the parent mapping.
-                    self.ser.current_map_depth = Some(self.depth);
-                    self.ser.after_dash_depth = None;
-                    key.serialize(&mut *self.ser)?;
-
-                    self.ser.depth = saved_depth;
-                    self.ser.current_map_depth = saved_current_map_depth;
-                    self.ser.pending_inline_map = saved_pending_inline_map;
-                    self.ser.inline_map_after_dash = saved_inline_map_after_dash;
-                    self.ser.after_dash_depth = saved_after_dash_depth;
-                    // A complex key may have been serialized as a block collection, which sets
-                    // `last_value_was_block`. That state must NOT affect the *value* of this same
-                    // map entry (e.g. we still want `: x: 3` inline for composite-key maps).
-                    self.ser.last_value_was_block = false;
-                    self.last_key_complex = true;
+                    self.write_explicit_key(key)?;
                 }
                 Err(e) => return Err(e),
             }

--- a/src/ser/compound.rs
+++ b/src/ser/compound.rs
@@ -416,6 +416,18 @@ impl<'a, 'b, W: Write> MapSer<'a, 'b, W> {
         Ok(())
     }
 
+    /// Emit an over-long scalar key in explicit `? key` form using its precomputed key-safe
+    /// `text`. Re-serializing via the value serializer would use value-position quoting and
+    /// could drop trailing whitespace, which YAML treats as separation in plain style.
+    fn write_explicit_scalar_key(&mut self, text: &str) -> Result<()> {
+        self.ser.write_indent(self.depth)?;
+        self.ser.out.write_str("? ")?;
+        self.ser.out.write_str(text)?;
+        self.ser.newline()?;
+        self.last_key_complex = true;
+        Ok(())
+    }
+
     /// Emit a key using the explicit `? key` form; the value follows on a `: value` line.
     fn write_explicit_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<()> {
         self.ser.write_anchor_for_complex_node()?;
@@ -494,7 +506,7 @@ impl<'a, 'b, W: Write> SerializeMap for MapSer<'a, 'b, W> {
                 {
                     self.write_simple_key(&text)?;
                 }
-                Ok(_) => self.write_explicit_key(key)?,
+                Ok(text) => self.write_explicit_scalar_key(&text)?,
                 Err(Error::Unexpected { msg }) if msg == "non-scalar key" => {
                     self.write_explicit_key(key)?;
                 }

--- a/src/ser/compound.rs
+++ b/src/ser/compound.rs
@@ -66,6 +66,7 @@ impl<'a, 'b, W: Write> SerializeSeq for SeqSer<'a, 'b, W> {
                 if !self.ser.at_line_start {
                     self.ser.newline()?;
                 }
+                self.ser.pending_inline_map = false;
             }
             // If previous element was an inline map after a dash, just clear the flag; do not change depth.
             if !self.first && self.ser.inline_map_after_dash {

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -1401,6 +1401,8 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
             self.write_plain_or_quoted(variant)?;
             self.out.write_str(":\n")?;
             self.at_line_start = true;
+            // A complex key stages an inline hint for its value; clear it before the fields.
+            self.pending_inline_map = false;
             // Fields indent one more level under the variant label.
             let depth_next = base + 1;
             return Ok(StructVariantSer {

--- a/src/ser/serializer.rs
+++ b/src/ser/serializer.rs
@@ -1244,6 +1244,7 @@ impl<'a, 'b, W: Write> Serializer for &'a mut YamlSerializer<'b, W> {
             self.write_plain_or_quoted(variant)?;
             self.out.write_str(":\n")?;
             self.at_line_start = true;
+            self.pending_inline_map = false;
             let depth_next = base + 1;
             return Ok(SeqSer {
                 ser: self,

--- a/tests/key_quoting.rs
+++ b/tests/key_quoting.rs
@@ -1,108 +1,149 @@
 #![cfg(all(feature = "serialize", feature = "deserialize"))]
-use std::collections::HashMap;
+use rstest::rstest;
+use serde::{Deserialize, Serialize};
+use serde_saphyr::{from_str, to_string};
+use std::collections::{BTreeMap, HashMap};
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_saphyr::{from_str, to_string};
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+enum TupleVariant {
+    Pair(BTreeMap<String, i64>, Option<i64>),
+}
 
-    /// Round-trips every printable ASCII single-character key (32..=126)
-    /// through serde_saphyr using the same pattern as the provided snippet.
-    /// This ensures that characters like comma `,` are serialized in a way
-    /// that can be parsed back into the same HashMap.
-    #[test]
-    fn printable_ascii_single_char_keys_roundtrip() {
-        for c in 32_u8..=126 {
-            let s = String::from_utf8(vec![c]).expect("valid UTF-8 single byte");
-            let mut h = HashMap::new();
-            h.insert(s.clone(), s.clone());
-
-            // NOTE: using the same pattern as the snippet:
-            // serialize then deserialize back into a HashMap<String, String>.
-            // If a key (e.g., ",") requires quoting, the serializer must emit it.
-            let yaml = to_string(&serde_saphyr::FlowSeq(h.clone()))
-                .expect("serialize FlowSeq<HashMap<..>>");
-            let parsed: HashMap<String, String> = from_str(&yaml)
-                .unwrap_or_else(|_| panic!("deserialize [{}] back into HashMap", yaml));
-
-            assert_eq!(parsed, h, "Round-trip failed for key {:?}", s);
-        }
-    }
-
-    /// Focused check for a comma key. This ensures that a map with `,` as a key
-    /// survives serialization and deserialization exactly.
-    #[test]
-    fn specific_key_roundtrip() {
+/// Round-trips every printable ASCII single-character key (32..=126)
+/// through serde_saphyr using the same pattern as the provided snippet.
+/// This ensures that characters like comma `,` are serialized in a way
+/// that can be parsed back into the same HashMap.
+#[test]
+fn printable_ascii_single_char_keys_roundtrip() {
+    for c in 32_u8..=126 {
+        let s = String::from_utf8(vec![c]).expect("valid UTF-8 single byte");
         let mut h = HashMap::new();
-        h.insert(",".to_string(), ",".to_string());
-        h.insert("".to_string(), " ".to_string()); // empty key
-        h.insert("null".to_string(), " ".to_string()); // null key
+        h.insert(s.clone(), s.clone());
 
-        // Serialize with the same FlowSeq wrapper as in the original snippet.
+        // NOTE: using the same pattern as the snippet:
+        // serialize then deserialize back into a HashMap<String, String>.
+        // If a key (e.g., ",") requires quoting, the serializer must emit it.
         let yaml =
             to_string(&serde_saphyr::FlowSeq(h.clone())).expect("serialize FlowSeq<HashMap<..>>");
-
-        // It must deserialize back to the identical map.
         let parsed: HashMap<String, String> =
             from_str(&yaml).unwrap_or_else(|_| panic!("deserialize [{}] back into HashMap", yaml));
 
-        assert_eq!(parsed, h, "Comma key/value did not round-trip as expected");
+        assert_eq!(parsed, h, "Round-trip failed for key {:?}", s);
     }
+}
 
-    #[test]
-    fn whitespace_padded_keys_roundtrip() {
-        let mut h = HashMap::new();
-        // if we were to trim or not quote the keys, they would collapse
-        h.insert("foo ".to_string(), "trailing".to_string());
-        h.insert("foo".to_string(), "bare".to_string());
-        h.insert(" foo".to_string(), "leading".to_string());
-        h.insert("foo bar".to_string(), "inner".to_string());
+/// Focused check for a comma key. This ensures that a map with `,` as a key
+/// survives serialization and deserialization exactly.
+#[test]
+fn specific_key_roundtrip() {
+    let mut h = HashMap::new();
+    h.insert(",".to_string(), ",".to_string());
+    h.insert("".to_string(), " ".to_string()); // empty key
+    h.insert("null".to_string(), " ".to_string()); // null key
 
-        let yaml = to_string(&h).expect("serialize HashMap with whitespace-padded keys");
+    // Serialize with the same FlowSeq wrapper as in the original snippet.
+    let yaml =
+        to_string(&serde_saphyr::FlowSeq(h.clone())).expect("serialize FlowSeq<HashMap<..>>");
 
-        let parsed: HashMap<String, String> = from_str(&yaml).unwrap();
-        assert_eq!(parsed, h);
+    // It must deserialize back to the identical map.
+    let parsed: HashMap<String, String> =
+        from_str(&yaml).unwrap_or_else(|_| panic!("deserialize [{}] back into HashMap", yaml));
+
+    assert_eq!(parsed, h, "Comma key/value did not round-trip as expected");
+}
+
+#[rstest]
+#[case(1023)]
+#[case(1024)]
+#[case(1025)]
+#[case(2000)]
+fn over_long_keys_roundtrip(#[case] len: usize) {
+    // A control char forces quoting, so the key is at least `len` chars long.
+    let key = "\u{7f}".repeat(len);
+    let mut h = HashMap::new();
+    h.insert(key.clone(), "v".to_string());
+    let mut outer = HashMap::new();
+    outer.insert("wrap".to_string(), h.clone());
+
+    let yaml = to_string(&outer).expect("serialize map with over-long key");
+    let parsed: HashMap<String, HashMap<String, String>> = from_str(&yaml)
+        .unwrap_or_else(|e| panic!("deserialize over-long key (len {len}) failed: {e}\n{yaml}"));
+    assert_eq!(
+        parsed, outer,
+        "over-long key (len {len}) did not round-trip"
+    );
+}
+
+/// A key past the 1024-char simple-key limit is emitted with the explicit `? key`
+/// form; its tuple-variant value must stay indented under the variant rather than
+/// dropping the first sequence dash to column 0.
+#[test]
+fn over_long_key_with_tuple_variant_value() {
+    let inner = BTreeMap::from([("a".to_string(), 1), ("b".to_string(), 2)]);
+    let value = TupleVariant::Pair(inner, None);
+
+    let mut m = BTreeMap::new();
+    m.insert("p".repeat(1100), value);
+
+    let yaml = to_string(&m).expect("serialize map with over-long explicit key");
+    let back: BTreeMap<String, TupleVariant> = from_str(&yaml)
+        .unwrap_or_else(|e| panic!("explicit-key tuple value failed to parse back: {e}\n{yaml}"));
+    assert_eq!(back, m);
+}
+
+#[test]
+fn whitespace_padded_keys_roundtrip() {
+    let mut h = HashMap::new();
+    // if we were to trim or not quote the keys, they would collapse
+    h.insert("foo ".to_string(), "trailing".to_string());
+    h.insert("foo".to_string(), "bare".to_string());
+    h.insert(" foo".to_string(), "leading".to_string());
+    h.insert("foo bar".to_string(), "inner".to_string());
+
+    let yaml = to_string(&h).expect("serialize HashMap with whitespace-padded keys");
+
+    let parsed: HashMap<String, String> = from_str(&yaml).unwrap();
+    assert_eq!(parsed, h);
+}
+
+/// Ensures that string keys that look like numbers ("1", "2.42") are quoted
+/// during serialization so they round-trip as strings, not numbers.
+#[test]
+fn numeric_string_keys_roundtrip() {
+    let mut map = HashMap::new();
+    map.insert("1".to_string(), "value1".to_string());
+    map.insert("2".to_string(), "value2".to_string());
+    map.insert("42".to_string(), "value42".to_string());
+    map.insert("-5".to_string(), "negative".to_string());
+    map.insert("3.14".to_string(), "pi".to_string());
+    // Oversized numeric-looking keys that can exceed common integer/float parsing ranges.
+    let huge_int = "9".repeat(200);
+    let huge_float_exp = "1e99999999".to_string();
+    map.insert(huge_int.clone(), "huge_int".to_string());
+    map.insert(huge_float_exp.clone(), "huge_float_exp".to_string());
+
+    let yaml = to_string(&map).expect("serialize HashMap with numeric string keys");
+
+    // The keys should be quoted in the YAML output
+    for value in [
+        "1",
+        "2",
+        "42",
+        "-5",
+        "3.14",
+        huge_int.as_str(),
+        huge_float_exp.as_str(),
+    ] {
+        assert!(
+            yaml.contains(&format!("\"{value}\"")),
+            "Key '{}' should be quoted in YAML output, got:\n{}",
+            value,
+            yaml
+        );
     }
+    // Verify they round-trip correctly as strings
+    let parsed: HashMap<String, String> =
+        from_str(&yaml).unwrap_or_else(|_| panic!("deserialize [{}] back into HashMap", yaml));
 
-    /// Ensures that string keys that look like numbers ("1", "2.42") are quoted
-    /// during serialization so they round-trip as strings, not numbers.
-    #[test]
-    fn numeric_string_keys_roundtrip() {
-        let mut map = HashMap::new();
-        map.insert("1".to_string(), "value1".to_string());
-        map.insert("2".to_string(), "value2".to_string());
-        map.insert("42".to_string(), "value42".to_string());
-        map.insert("-5".to_string(), "negative".to_string());
-        map.insert("3.14".to_string(), "pi".to_string());
-        // Oversized numeric-looking keys that can exceed common integer/float parsing ranges.
-        let huge_int = "9".repeat(200);
-        let huge_float_exp = "1e99999999".to_string();
-        map.insert(huge_int.clone(), "huge_int".to_string());
-        map.insert(huge_float_exp.clone(), "huge_float_exp".to_string());
-
-        let yaml = to_string(&map).expect("serialize HashMap with numeric string keys");
-
-        // The keys should be quoted in the YAML output
-        for value in [
-            "1",
-            "2",
-            "42",
-            "-5",
-            "3.14",
-            huge_int.as_str(),
-            huge_float_exp.as_str(),
-        ] {
-            assert!(
-                yaml.contains(&format!("\"{value}\"")),
-                "Key '{}' should be quoted in YAML output, got:\n{}",
-                value,
-                yaml
-            );
-        }
-        // Verify they round-trip correctly as strings
-        let parsed: HashMap<String, String> =
-            from_str(&yaml).unwrap_or_else(|_| panic!("deserialize [{}] back into HashMap", yaml));
-
-        assert_eq!(parsed, map);
-    }
+    assert_eq!(parsed, map);
 }

--- a/tests/long_strings.rs
+++ b/tests/long_strings.rs
@@ -3,6 +3,47 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_saphyr as yaml;
 use serde_saphyr::LitString;
+use std::collections::BTreeMap;
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+enum StructVariantEnum {
+    V { data: BTreeMap<String, i32> },
+}
+
+#[test]
+fn struct_variant_value_under_long_key_round_trips() -> anyhow::Result<()> {
+    // Over-long keys use the explicit `? key` form; the struct-variant value must not
+    // emit its nested map inline (e.g. `data: a: 1`), which would not parse back.
+    let mut data = BTreeMap::new();
+    data.insert("a".to_string(), 1);
+    data.insert("b".to_string(), 2);
+    let mut reference: BTreeMap<String, StructVariantEnum> = BTreeMap::new();
+    reference.insert("K".repeat(2000), StructVariantEnum::V { data });
+
+    let serialized = yaml::to_string(&reference)?;
+    let decoded: BTreeMap<String, StructVariantEnum> = yaml::from_str(&serialized)
+        .map_err(|e| anyhow::anyhow!("{e}\n--- yaml ---\n{serialized}"))?;
+    assert_eq!(reference, decoded);
+    Ok(())
+}
+
+#[test]
+fn long_scalar_key_with_trailing_space_round_trips() -> anyhow::Result<()> {
+    // With block scalars disabled, the explicit `? key` form must still quote the key so the
+    // trailing space is not lost as separation on the way back.
+    let key = "a".repeat(1024) + " ";
+    let mut reference: BTreeMap<String, i32> = BTreeMap::new();
+    reference.insert(key, 7);
+
+    let serialized = yaml::to_string_with_options(
+        &reference,
+        yaml::ser_options! { prefer_block_scalars: false },
+    )?;
+    let decoded: BTreeMap<String, i32> = yaml::from_str(&serialized)
+        .map_err(|e| anyhow::anyhow!("{e}\n--- yaml ---\n{serialized}"))?;
+    assert_eq!(reference, decoded);
+    Ok(())
+}
 
 #[derive(Serialize, Deserialize)]
 struct Foo {

--- a/tests/long_strings.rs
+++ b/tests/long_strings.rs
@@ -45,6 +45,26 @@ fn long_scalar_key_with_trailing_space_round_trips() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn sequence_value_under_long_key_in_nested_map_round_trips() -> anyhow::Result<()> {
+    let value = BTreeMap::from([("wrap", BTreeMap::from([("K".repeat(2000), vec![1, 2])]))]);
+    let serialized = yaml::to_string(&value)?;
+    let decoded = yaml::from_str(&serialized)
+        .map_err(|e| anyhow::anyhow!("{e}\n--- yaml ---\n{serialized}"))?;
+    assert_eq!(value, decoded);
+    Ok(())
+}
+
+#[test]
+fn tuple_value_under_long_key_in_nested_map_round_trips() -> anyhow::Result<()> {
+    let value = BTreeMap::from([("wrap", BTreeMap::from([("K".repeat(2000), (1, 2, 3))]))]);
+    let serialized = yaml::to_string(&value)?;
+    let decoded = yaml::from_str(&serialized)
+        .map_err(|e| anyhow::anyhow!("{e}\n--- yaml ---\n{serialized}"))?;
+    assert_eq!(value, decoded);
+    Ok(())
+}
+
 #[derive(Serialize, Deserialize)]
 struct Foo {
     a: i32,


### PR DESCRIPTION
another finding by the fuzzer.
If I pass a long string (1024 utf8 chars), this triggers some really unfortunate behaviour mangling indentation and the `?` case.

also cleaned up the testcase, mostly whitespace. See that option in github to disable whitespace.